### PR TITLE
fix: hash scroll race condition, abort signal race, Math.min empty array

### DIFF
--- a/src/api/openf1.ts
+++ b/src/api/openf1.ts
@@ -202,16 +202,16 @@ function sleep(ms: number, signal?: AbortSignal) {
     }, ms);
 
     function onAbort() {
+      signal?.removeEventListener('abort', onAbort);
       window.clearTimeout(timeoutId);
       reject(signal?.reason instanceof Error ? signal.reason : new DOMException('Request aborted', 'AbortError'));
     }
 
     if (signal) {
+      signal.addEventListener('abort', onAbort, { once: true });
       if (signal.aborted) {
         onAbort();
-        return;
       }
-      signal.addEventListener('abort', onAbort, { once: true });
     }
   });
 }
@@ -241,19 +241,23 @@ function combineSignals(signal?: AbortSignal, timeoutMs = DEFAULT_TIMEOUT_MS) {
     }
   };
 
-  const onSourceAbort = () => abort(signal.reason);
-  const onTimeoutAbort = () => abort(timeout.signal.reason);
-
-  if (signal.aborted) {
+  const onSourceAbort = () => {
+    signal.removeEventListener('abort', onSourceAbort);
     abort(signal.reason);
-  } else {
-    signal.addEventListener('abort', onSourceAbort, { once: true });
+  };
+  const onTimeoutAbort = () => {
+    timeout.signal.removeEventListener('abort', onTimeoutAbort);
+    abort(timeout.signal.reason);
+  };
+
+  signal.addEventListener('abort', onSourceAbort, { once: true });
+  if (signal.aborted) {
+    onSourceAbort();
   }
 
+  timeout.signal.addEventListener('abort', onTimeoutAbort, { once: true });
   if (timeout.signal.aborted) {
-    abort(timeout.signal.reason);
-  } else {
-    timeout.signal.addEventListener('abort', onTimeoutAbort, { once: true });
+    onTimeoutAbort();
   }
 
   return {

--- a/src/components/F1TelemetryDashboard.tsx
+++ b/src/components/F1TelemetryDashboard.tsx
@@ -363,26 +363,25 @@ export default function F1TelemetryDashboard() {
   useEffect(() => {
     if (typeof window === 'undefined') return;
 
-    const hash = window.location.hash.replace(/^#/, '');
-    if (!hash) return;
+    const targetId = window.location.hash.replace(/^#/, '');
+    if (!targetId) return;
 
     let attempts = 0;
-    const timer = window.setInterval(() => {
-      const target = window.document.getElementById(hash);
-      attempts += 1;
-
+    const timerId = window.setInterval(() => {
+      const target = window.document.getElementById(targetId);
       if (target) {
-        target.scrollIntoView({ block: 'start' });
-        window.clearInterval(timer);
+        target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        window.clearInterval(timerId);
         return;
       }
 
+      attempts += 1;
       if (attempts >= 12) {
-        window.clearInterval(timer);
+        window.clearInterval(timerId);
       }
     }, 120);
 
-    return () => window.clearInterval(timer);
+    return () => window.clearInterval(timerId);
   }, [filters.tab]);
 
   useEffect(() => {
@@ -758,9 +757,7 @@ export default function F1TelemetryDashboard() {
                 lapsLoading={lapsLoading}
                 sectorRows={viewModel.sectorRows}
                 lapSummaries={viewModel.lapSummaries}
-                driverNums={filters.driverNums}
                 driverMap={selectionData.driverMap}
-                driverColor={viewModel.driverColor}
                 embedMode={embedMode}
                 onEmbedPanel={handleEmbedPanel}
               />

--- a/src/components/dashboard/BroadcastTab.tsx
+++ b/src/components/dashboard/BroadcastTab.tsx
@@ -67,9 +67,7 @@ type Props = {
   lapsLoading: boolean;
   sectorRows: SectorRow[];
   lapSummaries: DriverLapSummary[];
-  driverNums: number[];
   driverMap: Record<number, OpenF1Driver>;
-  driverColor: (driverNumber: number) => string;
   embedMode?: boolean;
   onEmbedPanel?: (panelId: string) => void;
 };
@@ -81,9 +79,7 @@ export function BroadcastTab({
   lapsLoading,
   sectorRows,
   lapSummaries,
-  driverNums,
   driverMap,
-  driverColor,
   embedMode = false,
   onEmbedPanel,
 }: Props) {

--- a/src/components/dashboard/TelemetryTab.tsx
+++ b/src/components/dashboard/TelemetryTab.tsx
@@ -27,6 +27,13 @@ type Props = {
   onEmbedPanel?: (panelId: string) => void;
 };
 
+function getBestSector(rows: SectorRow[], key: 's1' | 's2' | 's3') {
+  const values = rows
+    .map((row) => row[key])
+    .filter((value): value is number => value != null);
+  return values.length > 0 ? Math.min(...values) : null;
+}
+
 export function TelemetryTab({
   lapNum,
   lapsLoading,
@@ -47,9 +54,9 @@ export function TelemetryTab({
   onEmbedPanel,
 }: Props) {
   const leader = lapSummaries[0];
-  const bestS1 = Math.min(...sectorRows.map((row) => row.s1 ?? Number.POSITIVE_INFINITY));
-  const bestS2 = Math.min(...sectorRows.map((row) => row.s2 ?? Number.POSITIVE_INFINITY));
-  const bestS3 = Math.min(...sectorRows.map((row) => row.s3 ?? Number.POSITIVE_INFINITY));
+  const bestS1 = getBestSector(sectorRows, 's1');
+  const bestS2 = getBestSector(sectorRows, 's2');
+  const bestS3 = getBestSector(sectorRows, 's3');
   const chartGrid = 'var(--chart-grid)';
   const chartAxis = 'var(--chart-axis)';
   const chartAxisSoft = 'var(--chart-axis-soft)';
@@ -212,13 +219,13 @@ export function TelemetryTab({
                   <tr key={row.name} className="border-b border-[color:var(--line)]">
                     <td className="py-2 text-xs font-bold" style={{ color: row.color }}>{row.name}</td>
                     <td className="py-2 text-right font-mono text-xs text-[color:var(--text-soft)]">
-                      <span style={row.s1 != null && row.s1 <= bestS1 ? { color: 'var(--accent)' } : undefined}>{row.s1?.toFixed(3) ?? '—'}</span>
+                      <span style={bestS1 != null && row.s1 != null && row.s1 <= bestS1 ? { color: 'var(--accent)' } : undefined}>{row.s1?.toFixed(3) ?? '—'}</span>
                     </td>
                     <td className="py-2 text-right font-mono text-xs text-[color:var(--text-soft)]">
-                      <span style={row.s2 != null && row.s2 <= bestS2 ? { color: 'var(--accent-strong)' } : undefined}>{row.s2?.toFixed(3) ?? '—'}</span>
+                      <span style={bestS2 != null && row.s2 != null && row.s2 <= bestS2 ? { color: 'var(--accent-strong)' } : undefined}>{row.s2?.toFixed(3) ?? '—'}</span>
                     </td>
                     <td className="py-2 text-right font-mono text-xs text-[color:var(--text-soft)]">
-                      <span style={row.s3 != null && row.s3 <= bestS3 ? { color: '#1AA34A' } : undefined}>{row.s3?.toFixed(3) ?? '—'}</span>
+                      <span style={bestS3 != null && row.s3 != null && row.s3 <= bestS3 ? { color: '#1AA34A' } : undefined}>{row.s3?.toFixed(3) ?? '—'}</span>
                     </td>
                     <td className="py-2 text-right text-xs font-bold font-mono text-[color:var(--text-strong)]">{fmtLap(row.total ?? null)}</td>
                     <td className="py-2 text-right font-mono text-xs text-[color:var(--accent-strong)]">{summary?.gapToLeader != null ? `+${summary.gapToLeader.toFixed(3)}` : '—'}</td>


### PR DESCRIPTION
## Summary
- fix abort cleanup races in the OpenF1 client
- harden hash-based scrolling cleanup in the dashboard shell
- guard telemetry sector benchmarks against empty data