### PR TITLE
perf: dynamic driver hooks, memoization, O(n) position bucketing

### DIFF
--- a/src/components/F1TelemetryDashboard.tsx
+++ b/src/components/F1TelemetryDashboard.tsx
@@ -40,6 +40,11 @@ type SavedPreset = {
 
 const PRESET_STORAGE_KEY = 'f1-telemetry-dashboard:presets';
 const THEME_STORAGE_KEY = 'f1-telemetry-dashboard:theme';
+const MAX_DRIVER_SLOTS = 4;
+const YEAR_OPTIONS = Array.from(
+  { length: new Date().getFullYear() - 2022 },
+  (_, index) => 2023 + index,
+);
 const TAB_LABELS = {
   telemetry: 'Telemetry',
   tires: 'Tyres & Strategy',
@@ -182,12 +187,16 @@ export default function F1TelemetryDashboard() {
   const sessions = useSessions(filters.year, filters.circuit);
   const drivers = useDrivers(filters.sessionKey);
   const sessionResults = useSessionResult(filters.sessionKey);
+  const driverSlots = useMemo(
+    () => Array.from({ length: MAX_DRIVER_SLOTS }, (_, index) => filters.driverNums[index] ?? null),
+    [filters.driverNums],
+  );
 
   const lapStates = [
-    useLaps(filters.sessionKey, filters.driverNums[0]),
-    useLaps(filters.sessionKey, filters.driverNums[1]),
-    useLaps(filters.sessionKey, filters.driverNums[2]),
-    useLaps(filters.sessionKey, filters.driverNums[3]),
+    useLaps(filters.sessionKey, driverSlots[0]),
+    useLaps(filters.sessionKey, driverSlots[1]),
+    useLaps(filters.sessionKey, driverSlots[2]),
+    useLaps(filters.sessionKey, driverSlots[3]),
   ];
 
   const stints = useStints(needsStrategyData ? filters.sessionKey : null);
@@ -220,35 +229,35 @@ export default function F1TelemetryDashboard() {
   const telemetryStates = [
     useLapTelemetry(
       filters.sessionKey,
-      filters.driverNums[0],
+      driverSlots[0],
       needsTelemetryData ? selectionData.telemetryWindows[0]?.lapStart || null : null,
       needsTelemetryData ? selectionData.telemetryWindows[0]?.nextLapStart || null : null,
     ),
     useLapTelemetry(
       filters.sessionKey,
-      filters.driverNums[1],
+      driverSlots[1],
       needsTelemetryData ? selectionData.telemetryWindows[1]?.lapStart || null : null,
       needsTelemetryData ? selectionData.telemetryWindows[1]?.nextLapStart || null : null,
     ),
     useLapTelemetry(
       filters.sessionKey,
-      filters.driverNums[2],
+      driverSlots[2],
       needsTelemetryData ? selectionData.telemetryWindows[2]?.lapStart || null : null,
       needsTelemetryData ? selectionData.telemetryWindows[2]?.nextLapStart || null : null,
     ),
     useLapTelemetry(
       filters.sessionKey,
-      filters.driverNums[3],
+      driverSlots[3],
       needsTelemetryData ? selectionData.telemetryWindows[3]?.lapStart || null : null,
       needsTelemetryData ? selectionData.telemetryWindows[3]?.nextLapStart || null : null,
     ),
   ];
 
   const locationStates = [
-    useLapLocation(needsLocationData ? filters.sessionKey : null, filters.driverNums[0], needsLocationData ? selectionData.telemetryWindows[0]?.lapStart || null : null, needsLocationData ? selectionData.telemetryWindows[0]?.nextLapStart || null : null),
-    useLapLocation(needsLocationData ? filters.sessionKey : null, filters.driverNums[1], needsLocationData ? selectionData.telemetryWindows[1]?.lapStart || null : null, needsLocationData ? selectionData.telemetryWindows[1]?.nextLapStart || null : null),
-    useLapLocation(needsLocationData ? filters.sessionKey : null, filters.driverNums[2], needsLocationData ? selectionData.telemetryWindows[2]?.lapStart || null : null, needsLocationData ? selectionData.telemetryWindows[2]?.nextLapStart || null : null),
-    useLapLocation(needsLocationData ? filters.sessionKey : null, filters.driverNums[3], needsLocationData ? selectionData.telemetryWindows[3]?.lapStart || null : null, needsLocationData ? selectionData.telemetryWindows[3]?.nextLapStart || null : null),
+    useLapLocation(needsLocationData ? filters.sessionKey : null, driverSlots[0], needsLocationData ? selectionData.telemetryWindows[0]?.lapStart || null : null, needsLocationData ? selectionData.telemetryWindows[0]?.nextLapStart || null : null),
+    useLapLocation(needsLocationData ? filters.sessionKey : null, driverSlots[1], needsLocationData ? selectionData.telemetryWindows[1]?.lapStart || null : null, needsLocationData ? selectionData.telemetryWindows[1]?.nextLapStart || null : null),
+    useLapLocation(needsLocationData ? filters.sessionKey : null, driverSlots[2], needsLocationData ? selectionData.telemetryWindows[2]?.lapStart || null : null, needsLocationData ? selectionData.telemetryWindows[2]?.nextLapStart || null : null),
+    useLapLocation(needsLocationData ? filters.sessionKey : null, driverSlots[3], needsLocationData ? selectionData.telemetryWindows[3]?.lapStart || null : null, needsLocationData ? selectionData.telemetryWindows[3]?.nextLapStart || null : null),
   ];
   const locationByDriver = Object.fromEntries(
     filters.driverNums.map((driverNum, index) => [driverNum, locationStates[index]?.data || null]),
@@ -288,10 +297,6 @@ export default function F1TelemetryDashboard() {
       setLapNum(nextLap);
     }
   }, [currentLapIndex, selectionData.lapOptions, setLapNum]);
-  const yearOptions = useMemo(
-    () => Array.from({ length: new Date().getFullYear() - 2022 }, (_, index) => 2023 + index),
-    [],
-  );
   const summaryPills = useMemo(() => {
     return viewModel.lapSummaries.slice(0, 2).map((summary, index) => ({
       label: `P${index + 1}`,
@@ -337,7 +342,7 @@ export default function F1TelemetryDashboard() {
   const embedContext = useMemo(
     () => [
       { label: 'Lap', value: `L${filters.lapNum}` },
-      { label: 'Drivers', value: `${filters.driverNums.length}/4` },
+      { label: 'Drivers', value: `${filters.driverNums.length}/${MAX_DRIVER_SLOTS}` },
       { label: 'View', value: TAB_LABELS[filters.tab] },
     ],
     [filters.driverNums.length, filters.lapNum, filters.tab],
@@ -576,7 +581,7 @@ export default function F1TelemetryDashboard() {
           sessionKey={filters.sessionKey}
           lapNum={filters.lapNum}
           totalLaps={totalLaps}
-          yearOptions={yearOptions}
+          yearOptions={YEAR_OPTIONS}
           circuitOptions={selectionData.circuitOptions}
           sessionOptions={selectionData.sessionOptions}
           lapOptions={selectionData.lapOptions}

--- a/src/components/dashboard/BroadcastTab.tsx
+++ b/src/components/dashboard/BroadcastTab.tsx
@@ -16,21 +16,66 @@ const SECTOR_STYLE: Record<SectorClass, { text: string; bg: string }> = {
   none:   { text: 'var(--text-muted)', bg: 'transparent' },
 };
 
-function classifySectors(rows: SectorRow[], field: 's1' | 's2' | 's3'): SectorClass[] {
-  const times = rows.map((row) => row[field] ?? null);
-  const valid = times.filter((t): t is number => t != null);
-  if (valid.length === 0) return rows.map(() => 'none');
+type IndexedSectorTime = {
+  index: number;
+  time: number;
+};
 
-  const sorted = [...valid].sort((a, b) => a - b);
-  const fastest = sorted[0];
-  const second = sorted.length > 2 ? sorted[1] : null;
+type SectorAnalysis = {
+  s1Classes: SectorClass[];
+  s2Classes: SectorClass[];
+  s3Classes: SectorClass[];
+  bestI1: number | null;
+  bestI2: number | null;
+  bestSt: number | null;
+};
 
-  return times.map((t) => {
-    if (t == null) return 'none';
-    if (t === fastest) return 'purple';
-    if (second != null && t === second) return 'green';
-    return 'yellow';
+function classifySectorEntries(entries: IndexedSectorTime[], rowCount: number): SectorClass[] {
+  const classes = Array.from({ length: rowCount }, () => 'none' as SectorClass);
+  if (entries.length === 0) return classes;
+
+  const sorted = entries.slice().sort((left, right) => left.time - right.time);
+  const fastest = sorted[0]?.time ?? null;
+  const second = sorted[1]?.time ?? null;
+
+  entries.forEach((entry) => {
+    if (fastest != null && entry.time === fastest) {
+      classes[entry.index] = 'purple';
+    } else if (second != null && entry.time === second) {
+      classes[entry.index] = 'green';
+    } else {
+      classes[entry.index] = 'yellow';
+    }
   });
+
+  return classes;
+}
+
+function buildSectorAnalysis(rows: SectorRow[]): SectorAnalysis {
+  const s1: IndexedSectorTime[] = [];
+  const s2: IndexedSectorTime[] = [];
+  const s3: IndexedSectorTime[] = [];
+  let bestI1: number | null = null;
+  let bestI2: number | null = null;
+  let bestSt: number | null = null;
+
+  rows.forEach((row, index) => {
+    if (row.s1 != null) s1.push({ index, time: row.s1 });
+    if (row.s2 != null) s2.push({ index, time: row.s2 });
+    if (row.s3 != null) s3.push({ index, time: row.s3 });
+    if (row.i1 != null) bestI1 = bestI1 == null ? row.i1 : Math.max(bestI1, row.i1);
+    if (row.i2 != null) bestI2 = bestI2 == null ? row.i2 : Math.max(bestI2, row.i2);
+    if (row.st != null) bestSt = bestSt == null ? row.st : Math.max(bestSt, row.st);
+  });
+
+  return {
+    s1Classes: classifySectorEntries(s1, rows.length),
+    s2Classes: classifySectorEntries(s2, rows.length),
+    s3Classes: classifySectorEntries(s3, rows.length),
+    bestI1,
+    bestI2,
+    bestSt,
+  };
 }
 
 // ─── Sector Time Cell ──────────────────────────────────────────────────────
@@ -96,24 +141,18 @@ export function BroadcastTab({
 
   const leaderTime = sorted[0]?.lapTime ?? null;
 
-  // Sector classifications
-  const s1Classes = useMemo(() => classifySectors(sectorRows, 's1'), [sectorRows]);
-  const s2Classes = useMemo(() => classifySectors(sectorRows, 's2'), [sectorRows]);
-  const s3Classes = useMemo(() => classifySectors(sectorRows, 's3'), [sectorRows]);
-
-  // Best speed trap readings (highest speed = purple)
-  const bestI1 = useMemo(() => {
-    const vals = sectorRows.map((r) => r.i1).filter((v): v is number => v != null);
-    return vals.length > 0 ? Math.max(...vals) : null;
-  }, [sectorRows]);
-  const bestI2 = useMemo(() => {
-    const vals = sectorRows.map((r) => r.i2).filter((v): v is number => v != null);
-    return vals.length > 0 ? Math.max(...vals) : null;
-  }, [sectorRows]);
-  const bestSt = useMemo(() => {
-    const vals = sectorRows.map((r) => r.st).filter((v): v is number => v != null);
-    return vals.length > 0 ? Math.max(...vals) : null;
-  }, [sectorRows]);
+  const { s1Classes, s2Classes, s3Classes, bestI1, bestI2, bestSt } = useMemo(
+    () => buildSectorAnalysis(sectorRows),
+    [sectorRows],
+  );
+  const summaryByName = useMemo(
+    () => Object.fromEntries(lapSummaries.map((summary) => [summary.name, summary])) as Record<string, DriverLapSummary>,
+    [lapSummaries],
+  );
+  const sectorRowMetaByName = useMemo(
+    () => Object.fromEntries(sectorRows.map((row, index) => [row.name, { row, index }])) as Record<string, { row: SectorRow; index: number }>,
+    [sectorRows],
+  );
 
   const hasSectors = sectorRows.some((r) => r.total != null);
   const hasSpeedTraps = sectorRows.some((r) => r.i1 != null || r.i2 != null || r.st != null);
@@ -258,7 +297,7 @@ export function BroadcastTab({
               </thead>
               <tbody>
                 {sectorRows.map((row, rowIndex) => {
-                  const summary = lapSummaries.find((s) => s.name === row.name);
+                  const summary = summaryByName[row.name];
                   return (
                     <tr key={row.name} className="bc-sector-row">
                       <td className="bc-sector-driver-cell">
@@ -358,9 +397,8 @@ export function BroadcastTab({
               const driver = driverMap[summary.driverNumber];
               const color = summary.color;
               const isLeader = pos === 1;
-
-              // Find sector data for this driver
-              const sectorRow = sectorRows.find((r) => r.name === (driver?.name_acronym ?? `#${summary.driverNumber}`));
+              const sectorMeta = sectorRowMetaByName[driver?.name_acronym ?? `#${summary.driverNumber}`];
+              const sectorRow = sectorMeta?.row;
 
               return (
                 <div key={summary.driverNumber} className="bc-driver-card">
@@ -405,12 +443,11 @@ export function BroadcastTab({
                     ) : null}
 
                     {/* Sector mini-display */}
-                    {sectorRow && (sectorRow.s1 != null || sectorRow.s2 != null || sectorRow.s3 != null) && (() => {
-                      const rowIdx = sectorRows.indexOf(sectorRow);
+                    {sectorMeta && sectorRow && (sectorRow.s1 != null || sectorRow.s2 != null || sectorRow.s3 != null) && (() => {
                       const classes = [
-                        s1Classes[rowIdx] ?? 'none',
-                        s2Classes[rowIdx] ?? 'none',
-                        s3Classes[rowIdx] ?? 'none',
+                        s1Classes[sectorMeta.index] ?? 'none',
+                        s2Classes[sectorMeta.index] ?? 'none',
+                        s3Classes[sectorMeta.index] ?? 'none',
                       ];
                       const times = [sectorRow.s1, sectorRow.s2, sectorRow.s3];
                       return (

--- a/src/components/dashboard/PositionsTab.tsx
+++ b/src/components/dashboard/PositionsTab.tsx
@@ -18,6 +18,10 @@ type Props = {
 };
 
 const MAX_CHART_POINTS = 100;
+type PositionSample = {
+  position: number;
+  timestamp: number;
+};
 
 export function PositionsTab({ driverNums, driverMap, positions, positionsLoading, lapNum, driverColor, embedMode = false, onEmbedPanel }: Props) {
   const chartGrid = 'var(--chart-grid)';
@@ -26,43 +30,62 @@ export function PositionsTab({ driverNums, driverMap, positions, positionsLoadin
   const { chartData, totalLaps, driverCount } = useMemo(() => {
     if (!positions || positions.length === 0) return { chartData: [], totalLaps: 0, driverCount: 0 };
 
-    // Group by lap-level buckets using date ordering.
-    // Position endpoint gives a snapshot every ~few seconds — we sample by time bucket.
-    const byDriver: Record<number, OpenF1Position[]> = {};
-    for (const p of positions) {
-      (byDriver[p.driver_number] ||= []).push(p);
-    }
+    const byDriver = new Map<number, PositionSample[]>();
+    let tMin = Number.POSITIVE_INFINITY;
+    let tMax = Number.NEGATIVE_INFINITY;
 
-    // Find all unique drivers present
-    const allDrivers = Object.keys(byDriver).map(Number);
+    positions.forEach((entry) => {
+      const timestamp = Date.parse(entry.date);
+      if (!Number.isFinite(timestamp)) return;
 
-    // Determine time range
-    const allDates = positions.map((p) => new Date(p.date).getTime());
-    const tMin = Math.min(...allDates);
-    const tMax = Math.max(...allDates);
-    const duration = tMax - tMin || 1;
+      tMin = Math.min(tMin, timestamp);
+      tMax = Math.max(tMax, timestamp);
 
-    // Build N evenly-spaced time buckets
-    const N = MAX_CHART_POINTS;
-    const buckets = Array.from({ length: N }, (_, i) => {
-      const t = tMin + (i / (N - 1)) * duration;
-      const point: Record<string, number | string> = { t: i + 1 };
-      for (const dNum of allDrivers) {
-        const samples = byDriver[dNum];
-        // find closest sample to time t
-        let best: OpenF1Position | null = null;
-        let bestDiff = Infinity;
-        for (const s of samples) {
-          const diff = Math.abs(new Date(s.date).getTime() - t);
-          if (diff < bestDiff) { bestDiff = diff; best = s; }
-        }
-        if (best) point[`p_${dNum}`] = best.position;
+      const samples = byDriver.get(entry.driver_number);
+      const sample = { position: entry.position, timestamp };
+      if (samples) {
+        samples.push(sample);
+      } else {
+        byDriver.set(entry.driver_number, [sample]);
       }
-      return point;
     });
 
-    // Estimate total laps from max position samples count / 20 (rough heuristic)
-    const totalSamples = Math.max(...allDrivers.map((d) => byDriver[d].length));
+    const allDrivers = [...byDriver.keys()];
+    if (allDrivers.length === 0 || !Number.isFinite(tMin) || !Number.isFinite(tMax)) {
+      return { chartData: [], totalLaps: 0, driverCount: 0 };
+    }
+
+    byDriver.forEach((samples) => {
+      samples.sort((left, right) => left.timestamp - right.timestamp);
+    });
+
+    const duration = tMax - tMin || 1;
+
+    const bucketTimes = Array.from({ length: MAX_CHART_POINTS }, (_, index) => (
+      tMin + (index / (MAX_CHART_POINTS - 1)) * duration
+    ));
+    const buckets = bucketTimes.map((_, index) => ({ t: index + 1 } as Record<string, number | string>));
+
+    allDrivers.forEach((driverNumber) => {
+      const samples = byDriver.get(driverNumber);
+      if (!samples?.length) return;
+
+      let pointer = 0;
+      bucketTimes.forEach((bucketTime, bucketIndex) => {
+        while (pointer + 1 < samples.length && samples[pointer + 1].timestamp <= bucketTime) {
+          pointer += 1;
+        }
+
+        const current = samples[pointer];
+        const next = samples[pointer + 1];
+        const best = next && Math.abs(next.timestamp - bucketTime) < Math.abs(current.timestamp - bucketTime)
+          ? next
+          : current;
+        buckets[bucketIndex][`p_${driverNumber}`] = best.position;
+      });
+    });
+
+    const totalSamples = Math.max(0, ...allDrivers.map((driverNumber) => byDriver.get(driverNumber)?.length ?? 0));
     const estLaps = Math.round(totalSamples / 20);
 
     return { chartData: buckets, totalLaps: estLaps, driverCount: allDrivers.length };

--- a/src/components/dashboard/RadioTab.tsx
+++ b/src/components/dashboard/RadioTab.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import { Headphones } from 'lucide-react';
 import type { OpenF1Driver, OpenF1TeamRadio } from '../../api/openf1';
 import { Err, NoData, Panel, Spinner } from './shared';
@@ -10,27 +11,39 @@ type Props = {
 };
 
 export function RadioTab({ loading, error, messages, driverMap }: Props) {
+  const radioMessages = useMemo(
+    () => messages.map((message, index) => {
+      const driver = driverMap[message.driver_number];
+      const teamColor = `#${driver?.team_colour || '888'}`;
+      return {
+        key: `${message.driver_number}-${message.date}-${index}`,
+        driverLabel: driver?.name_acronym || `#${message.driver_number}`,
+        teamColor,
+        timeLabel: new Date(message.date).toLocaleTimeString(),
+        recordingUrl: message.recording_url,
+      };
+    }),
+    [driverMap, messages],
+  );
+
   return (
     <Panel title="Team Radio Recordings" icon={<Headphones size={14} style={{ color: 'var(--accent)' }} />} sub="Click to listen to actual team radio recordings from the session">
-      {loading ? <Spinner /> : error ? <Err msg={error} /> : messages.length > 0 ? (
+      {loading ? <Spinner /> : error ? <Err msg={error} /> : radioMessages.length > 0 ? (
         <div className="max-h-[500px] space-y-3 overflow-y-auto pr-2">
-          {messages.map((message, index) => {
-            const driver = driverMap[message.driver_number];
-            return (
-              <div key={index} className="dashboard-card flex gap-3 rounded-[14px] p-3">
-                <div className="mt-1.5 h-2 w-2 shrink-0 rounded-full" style={{ backgroundColor: `#${driver?.team_colour || '888'}` }} />
-                <div className="flex-1">
-                  <div className="mb-1 flex items-center gap-2">
-                    <span className="text-xs font-bold tracking-[0.2em]" style={{ color: `#${driver?.team_colour || '888'}` }}>{driver?.name_acronym || `#${message.driver_number}`}</span>
-                    <span className="rounded-full bg-[color:var(--surface-soft)] px-2 py-0.5 text-[9px] uppercase tracking-[0.18em] text-[color:var(--text-muted)]">{new Date(message.date).toLocaleTimeString()}</span>
-                  </div>
-                  <a href={message.recording_url} target="_blank" rel="noopener noreferrer" className="inline-flex items-center gap-1 rounded-[10px] border border-[color:var(--accent-border)] bg-[color:var(--accent-muted)] px-3 py-2 text-xs uppercase tracking-[0.16em] text-[color:var(--accent)] transition-colors duration-200 hover:text-[color:var(--accent-hover)]">
-                    <Headphones size={10} /> Play recording ↗
-                  </a>
+          {radioMessages.map((message) => (
+            <div key={message.key} className="dashboard-card flex gap-3 rounded-[14px] p-3">
+              <div className="mt-1.5 h-2 w-2 shrink-0 rounded-full" style={{ backgroundColor: message.teamColor }} />
+              <div className="flex-1">
+                <div className="mb-1 flex items-center gap-2">
+                  <span className="text-xs font-bold tracking-[0.2em]" style={{ color: message.teamColor }}>{message.driverLabel}</span>
+                  <span className="rounded-full bg-[color:var(--surface-soft)] px-2 py-0.5 text-[9px] uppercase tracking-[0.18em] text-[color:var(--text-muted)]">{message.timeLabel}</span>
                 </div>
+                <a href={message.recordingUrl} target="_blank" rel="noopener noreferrer" className="inline-flex items-center gap-1 rounded-[10px] border border-[color:var(--accent-border)] bg-[color:var(--accent-muted)] px-3 py-2 text-xs uppercase tracking-[0.16em] text-[color:var(--accent)] transition-colors duration-200 hover:text-[color:var(--accent-hover)]">
+                  <Headphones size={10} /> Play recording ↗
+                </a>
               </div>
-            );
-          })}
+            </div>
+          ))}
         </div>
       ) : <NoData msg="No team radio recordings for this session/driver selection." />}
     </Panel>

--- a/src/components/dashboard/StrategyTab.tsx
+++ b/src/components/dashboard/StrategyTab.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import { CircleDot, Timer } from 'lucide-react';
 import type { OpenF1Driver, OpenF1Pit, OpenF1Stint } from '../../api/openf1';
 import { EmbedPanelButton, NoData, Panel, Spinner } from './shared';
@@ -27,7 +28,119 @@ type Props = {
   onEmbedPanel?: (panelId: string) => void;
 };
 
+type StrategyRow = {
+  driverNumber: number;
+  acronym: string;
+  teamColor: string;
+  stintCount: number;
+  segments: Array<{
+    key: string;
+    width: number;
+    color: string;
+    compound: string;
+    title: string;
+    rangeLabel: string;
+  }>;
+};
+
+type TyreLifeCard = {
+  driverNumber: number;
+  acronym: string;
+  teamColor: string;
+  compound: string;
+  compoundColor: string;
+  remaining: number;
+  stintAge: number;
+  stopEstimate: number;
+};
+
+type PitStopCard = {
+  key: string;
+  acronym: string;
+  teamColor: string;
+  stopDuration: string;
+  pitLaneDuration: string;
+  lapNumber: number;
+};
+
 export function StrategyTab({ lapNum, driverNums, driverMap, stintsLoading, stintsByDriver, pitsLoading, filteredPits, embedMode = false, onEmbedPanel }: Props) {
+  const fallbackDriverNums = useMemo(() => Object.keys(stintsByDriver).map(Number), [stintsByDriver]);
+  const strategyDriverNums = useMemo(
+    () => (driverNums.length > 0 ? driverNums : fallbackDriverNums.slice(0, 6)),
+    [driverNums, fallbackDriverNums],
+  );
+  const tyreLifeDriverNums = useMemo(
+    () => (driverNums.length > 0 ? driverNums : fallbackDriverNums.slice(0, 4)),
+    [driverNums, fallbackDriverNums],
+  );
+  const strategyRows = useMemo<StrategyRow[]>(
+    () => strategyDriverNums
+      .map((driverNumber) => {
+        const driver = driverMap[driverNumber];
+        const driverStints = stintsByDriver[driverNumber];
+        if (!driver || !driverStints?.length) return null;
+
+        const maxLap = Math.max(...driverStints.map((stint) => stint.lap_end || 0), 1);
+        return {
+          driverNumber,
+          acronym: driver.name_acronym,
+          teamColor: `#${driver.team_colour}`,
+          stintCount: driverStints.length,
+          segments: driverStints.map((stint, index) => {
+            const compound = (stint.compound || 'UNKNOWN').toUpperCase();
+            const color = COMPOUND_COLORS[compound] || COMPOUND_COLORS.UNKNOWN;
+            return {
+              key: `${driverNumber}-${index}`,
+              width: Math.max(3, ((stint.lap_end - stint.lap_start + 1) / maxLap) * 100),
+              color,
+              compound,
+              title: `${compound}: Lap ${stint.lap_start}-${stint.lap_end}`,
+              rangeLabel: `${stint.lap_start}-${stint.lap_end}`,
+            };
+          }),
+        };
+      })
+      .filter((row): row is StrategyRow => row != null),
+    [driverMap, strategyDriverNums, stintsByDriver],
+  );
+  const tyreLifeCards = useMemo<TyreLifeCard[]>(
+    () => tyreLifeDriverNums
+      .map((driverNumber) => {
+        const driver = driverMap[driverNumber];
+        const activeStint = stintsByDriver[driverNumber]?.find((stint) => lapNum >= stint.lap_start && lapNum <= stint.lap_end);
+        if (!driver || !activeStint) return null;
+
+        const compound = (activeStint.compound || 'UNKNOWN').toUpperCase();
+        return {
+          driverNumber,
+          acronym: driver.name_acronym,
+          teamColor: `#${driver.team_colour}`,
+          compound,
+          compoundColor: COMPOUND_COLORS[compound] || COMPOUND_COLORS.UNKNOWN,
+          remaining: Math.max(0, activeStint.lap_end - lapNum),
+          stintAge: lapNum - activeStint.lap_start + 1,
+          stopEstimate: activeStint.lap_end,
+        };
+      })
+      .filter((card): card is TyreLifeCard => card != null),
+    [driverMap, lapNum, stintsByDriver, tyreLifeDriverNums],
+  );
+  const pitStopCards = useMemo<PitStopCard[]>(
+    () => filteredPits.map((pit, index) => {
+      const driver = driverMap[pit.driver_number];
+      const teamColor = `#${driver?.team_colour || '888'}`;
+      return {
+        key: `${pit.driver_number}-${pit.lap_number}-${pit.date}-${index}`,
+        acronym: driver?.name_acronym || `#${pit.driver_number}`,
+        teamColor,
+        stopDuration: pit.stop_duration?.toFixed(1) || '—',
+        pitLaneDuration: pit.pit_duration?.toFixed(1) || '—',
+        lapNumber: pit.lap_number,
+      };
+    }),
+    [driverMap, filteredPits],
+  );
+
   return (
     <>
       <Panel
@@ -37,96 +150,74 @@ export function StrategyTab({ lapNum, driverNums, driverMap, stintsLoading, stin
         panelId="strategy-tyre-strategy"
         headerRight={embedMode && onEmbedPanel ? <EmbedPanelButton onClick={() => onEmbedPanel('strategy-tyre-strategy')} /> : undefined}
       >
-        {stintsLoading ? <Spinner label="Loading stint data…" /> : Object.keys(stintsByDriver).length > 0 ? (
+        {stintsLoading ? <Spinner label="Loading stint data…" /> : strategyRows.length > 0 ? (
           <div className="space-y-3">
-            {(driverNums.length > 0 ? driverNums : Object.keys(stintsByDriver).map(Number).slice(0, 6)).map((driverNumber) => {
-              const driver = driverMap[driverNumber];
-              const driverStints = stintsByDriver[driverNumber];
-              if (!driver || !driverStints?.length) return null;
-              const maxLap = Math.max(...driverStints.map((stint) => stint.lap_end || 0), 1);
-              return (
-                <div key={driverNumber} className="grid gap-2 sm:grid-cols-[64px_1fr_56px] sm:items-center sm:gap-4">
-                  <div className="flex items-center justify-between sm:block sm:text-right"><span className="text-xs font-bold tracking-[0.2em]" style={{ color: `#${driver.team_colour}` }}>{driver.name_acronym}</span></div>
-                  <div className="dashboard-card flex h-9 flex-1 overflow-hidden rounded-[12px]">
-                    {driverStints.map((stint, index) => {
-                      const width = Math.max(3, ((stint.lap_end - stint.lap_start + 1) / maxLap) * 100);
-                      const compound = (stint.compound || 'UNKNOWN').toUpperCase();
-                      const color = COMPOUND_COLORS[compound] || COMPOUND_COLORS.UNKNOWN;
-                      return (
-                        <div
-                          key={index}
-                          className="flex h-full min-w-[24px] items-center justify-center border-r border-[color:var(--line-strong)] text-[10px] font-bold"
-                          style={{ width: `${width}%`, backgroundColor: `${color}18`, color }}
-                          title={`${compound}: Lap ${stint.lap_start}–${stint.lap_end}`}
-                        >
-                          {compound.charAt(0)}
-                          <span className="ml-1 hidden opacity-40 sm:inline">{stint.lap_start}-{stint.lap_end}</span>
-                        </div>
-                      );
-                    })}
-                  </div>
-                  <div className="text-right text-[10px] uppercase tracking-[0.16em] text-[color:var(--text-muted)]">{driverStints.length} stint{driverStints.length > 1 ? 's' : ''}</div>
+            {strategyRows.map((row) => (
+              <div key={row.driverNumber} className="grid gap-2 sm:grid-cols-[64px_1fr_56px] sm:items-center sm:gap-4">
+                <div className="flex items-center justify-between sm:block sm:text-right"><span className="text-xs font-bold tracking-[0.2em]" style={{ color: row.teamColor }}>{row.acronym}</span></div>
+                <div className="dashboard-card flex h-9 flex-1 overflow-hidden rounded-[12px]">
+                  {row.segments.map((segment) => (
+                    <div
+                      key={segment.key}
+                      className="flex h-full min-w-[24px] items-center justify-center border-r border-[color:var(--line-strong)] text-[10px] font-bold"
+                      style={{ width: `${segment.width}%`, backgroundColor: `${segment.color}18`, color: segment.color }}
+                      title={segment.title}
+                    >
+                      {segment.compound.charAt(0)}
+                      <span className="ml-1 hidden opacity-40 sm:inline">{segment.rangeLabel}</span>
+                    </div>
+                  ))}
                 </div>
-              );
-            })}
+                <div className="text-right text-[10px] uppercase tracking-[0.16em] text-[color:var(--text-muted)]">{row.stintCount} stint{row.stintCount > 1 ? 's' : ''}</div>
+              </div>
+            ))}
           </div>
         ) : <NoData msg="No stint data for this session. Stint data is typically available for race and sprint sessions." />}
       </Panel>
 
       <Panel title="Tyre Life Projection" icon={<CircleDot size={14} style={{ color: 'var(--accent-strong)' }} />} sub="Current stint context at the focused lap">
-        {Object.keys(stintsByDriver).length > 0 ? (
+        {tyreLifeCards.length > 0 ? (
           <div className="grid gap-3 lg:grid-cols-2">
-            {(driverNums.length > 0 ? driverNums : Object.keys(stintsByDriver).map(Number).slice(0, 4)).map((driverNumber) => {
-              const driver = driverMap[driverNumber];
-              const activeStint = stintsByDriver[driverNumber]?.find((stint) => lapNum >= stint.lap_start && lapNum <= stint.lap_end);
-              if (!driver || !activeStint) return null;
-              const remaining = Math.max(0, activeStint.lap_end - lapNum);
-              const compound = (activeStint.compound || 'UNKNOWN').toUpperCase();
-              const color = COMPOUND_COLORS[compound] || COMPOUND_COLORS.UNKNOWN;
-              return (
-                <div key={driverNumber} className="dashboard-card rounded-[16px] p-4">
-                  <div className="mb-3 flex items-center justify-between">
-                    <span className="text-xs font-black tracking-[0.2em]" style={{ color: `#${driver.team_colour}` }}>{driver.name_acronym}</span>
-                    <span className="rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.18em]" style={{ backgroundColor: `${color}1c`, color }}>{compound}</span>
+            {tyreLifeCards.map((card) => (
+              <div key={card.driverNumber} className="dashboard-card rounded-[16px] p-4">
+                <div className="mb-3 flex items-center justify-between">
+                  <span className="text-xs font-black tracking-[0.2em]" style={{ color: card.teamColor }}>{card.acronym}</span>
+                  <span className="rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.18em]" style={{ backgroundColor: `${card.compoundColor}1c`, color: card.compoundColor }}>{card.compound}</span>
+                </div>
+                <div className="mb-3 text-3xl font-black text-emerald-300">{card.remaining}</div>
+                <div className="grid grid-cols-3 gap-3 text-[10px] uppercase tracking-[0.16em] text-[color:var(--text-muted)]">
+                  <div>
+                    <div className="mb-1 text-[color:var(--text-dim)]">Laps Left</div>
+                    <div className="font-mono text-[color:var(--text-soft)]">{card.remaining}</div>
                   </div>
-                  <div className="mb-3 text-3xl font-black text-emerald-300">{remaining}</div>
-                  <div className="grid grid-cols-3 gap-3 text-[10px] uppercase tracking-[0.16em] text-[color:var(--text-muted)]">
-                    <div>
-                      <div className="mb-1 text-[color:var(--text-dim)]">Laps Left</div>
-                      <div className="font-mono text-[color:var(--text-soft)]">{remaining}</div>
-                    </div>
-                    <div>
-                      <div className="mb-1 text-[color:var(--text-dim)]">Stint Age</div>
-                      <div className="font-mono text-[color:var(--text-soft)]">{lapNum - activeStint.lap_start + 1}</div>
-                    </div>
-                    <div>
-                      <div className="mb-1 text-[color:var(--text-dim)]">Stop Est.</div>
-                      <div className="font-mono text-[color:var(--text-soft)]">L{activeStint.lap_end}</div>
-                    </div>
+                  <div>
+                    <div className="mb-1 text-[color:var(--text-dim)]">Stint Age</div>
+                    <div className="font-mono text-[color:var(--text-soft)]">{card.stintAge}</div>
+                  </div>
+                  <div>
+                    <div className="mb-1 text-[color:var(--text-dim)]">Stop Est.</div>
+                    <div className="font-mono text-[color:var(--text-soft)]">L{card.stopEstimate}</div>
                   </div>
                 </div>
-              );
-            })}
+              </div>
+            ))}
           </div>
         ) : <NoData msg="No active stint context available for this lap." />}
       </Panel>
 
       <Panel title="Pit Stops" icon={<Timer size={14} style={{ color: 'var(--accent)' }} />} sub="Ordered by stationary time">
-        {pitsLoading ? <Spinner /> : filteredPits.length > 0 ? (
+        {pitsLoading ? <Spinner /> : pitStopCards.length > 0 ? (
           <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4">
-            {filteredPits.map((pit, index) => {
-              const driver = driverMap[pit.driver_number];
-              return (
-                <div key={index} className="dashboard-card rounded-[16px] p-3">
-                  <div className="mb-2 flex items-center gap-2">
-                    <span className="h-2 w-2 rounded-full" style={{ backgroundColor: `#${driver?.team_colour || '888'}` }} />
-                    <span className="text-xs font-bold tracking-[0.2em]" style={{ color: `#${driver?.team_colour || '888'}` }}>{driver?.name_acronym || `#${pit.driver_number}`}</span>
-                  </div>
-                  <div className="text-xl font-black font-mono text-[color:var(--text-strong)]">{pit.stop_duration?.toFixed(1) || '—'}<span className="text-sm text-[color:var(--text-muted)]">s</span></div>
-                  <div className="text-[10px] uppercase tracking-[0.15em] text-[color:var(--text-muted)]">Lap {pit.lap_number} · Pit lane: {pit.pit_duration?.toFixed(1)}s</div>
+            {pitStopCards.map((card) => (
+              <div key={card.key} className="dashboard-card rounded-[16px] p-3">
+                <div className="mb-2 flex items-center gap-2">
+                  <span className="h-2 w-2 rounded-full" style={{ backgroundColor: card.teamColor }} />
+                  <span className="text-xs font-bold tracking-[0.2em]" style={{ color: card.teamColor }}>{card.acronym}</span>
                 </div>
-              );
-            })}
+                <div className="text-xl font-black font-mono text-[color:var(--text-strong)]">{card.stopDuration}<span className="text-sm text-[color:var(--text-muted)]">s</span></div>
+                <div className="text-[10px] uppercase tracking-[0.15em] text-[color:var(--text-muted)]">Lap {card.lapNumber} · Pit lane: {card.pitLaneDuration}s</div>
+              </div>
+            ))}
           </div>
         ) : <NoData msg="No pit stop data for this session." />}
       </Panel>

--- a/src/components/dashboard/TrackMapTab.tsx
+++ b/src/components/dashboard/TrackMapTab.tsx
@@ -17,6 +17,11 @@ type Props = {
 const MAP_W = 600;
 const MAP_H = 380;
 const PADDING = 36;
+type DriverMarker = {
+  nx: number;
+  ny: number;
+  label: string;
+};
 
 function subsample<T>(arr: T[], max: number): T[] {
   if (arr.length <= max) return arr;
@@ -48,10 +53,12 @@ function toPolyline(pts: { nx: number; ny: number }[]) {
 }
 
 export function TrackMapTab({ lapNum, driverNums, driverMap, locationByDriver, locationLoading, driverColor, embedMode = false, onEmbedPanel }: Props) {
-  const { trackPolyline, driverPaths, startPt } = useMemo((): {
+  const { trackPolyline, driverPaths, driverMarkers, startPt, activeDrivers } = useMemo((): {
     trackPolyline: string;
     driverPaths: Partial<Record<number, string>>;
+    driverMarkers: Partial<Record<number, DriverMarker>>;
     startPt: { nx: number; ny: number } | null;
+    activeDrivers: number[];
   } => {
     // Use all drivers' data combined to get the best track outline
     const allRaw = driverNums
@@ -59,7 +66,15 @@ export function TrackMapTab({ lapNum, driverNums, driverMap, locationByDriver, l
       .map((p) => ({ x: p.x, y: p.y }));
 
     const transform = buildTransform(allRaw);
-    if (!transform) return { trackPolyline: '', driverPaths: {} as Partial<Record<number, string>>, startPt: null };
+    if (!transform) {
+      return {
+        trackPolyline: '',
+        driverPaths: {} as Partial<Record<number, string>>,
+        driverMarkers: {} as Partial<Record<number, DriverMarker>>,
+        startPt: null,
+        activeDrivers: [],
+      };
+    }
 
     // Track outline from the driver with the most data
     const refDriver = [...driverNums].sort(
@@ -72,15 +87,28 @@ export function TrackMapTab({ lapNum, driverNums, driverMap, locationByDriver, l
 
     // Per-driver paths
     const paths: Partial<Record<number, string>> = {};
+    const markers: Partial<Record<number, DriverMarker>> = {};
+    const active: number[] = [];
     for (const n of driverNums) {
       const pts = subsample(locationByDriver[n] ?? [], 400).map((p) => transform({ x: p.x, y: p.y }));
-      if (pts.length > 1) paths[n] = toPolyline(pts);
+      if (pts.length > 1) {
+        paths[n] = toPolyline(pts);
+        active.push(n);
+      }
+
+      const rawPoints = locationByDriver[n] ?? [];
+      const last = rawPoints[rawPoints.length - 1];
+      if (last) {
+        const marker = transform({ x: last.x, y: last.y });
+        markers[n] = {
+          ...marker,
+          label: driverMap[n]?.name_acronym?.slice(0, 3) ?? '?',
+        };
+      }
     }
 
-    return { trackPolyline: outline, driverPaths: paths, startPt: first };
-  }, [driverNums, locationByDriver]);
-
-  const activeDrivers = driverNums.filter((n) => driverPaths[n] != null);
+    return { trackPolyline: outline, driverPaths: paths, driverMarkers: markers, startPt: first, activeDrivers: active };
+  }, [driverMap, driverNums, locationByDriver]);
 
   if (locationLoading) return <Spinner label="Fetching GPS location data…" />;
   if (!trackPolyline) {
@@ -135,19 +163,13 @@ export function TrackMapTab({ lapNum, driverNums, driverMap, locationByDriver, l
 
             {/* Driver end-position markers */}
             {activeDrivers.map((n) => {
-              const pts = locationByDriver[n] ?? [];
-              if (pts.length === 0) return null;
-              const last = pts[pts.length - 1];
-              // Quick re-transform for last point
-              const allRaw = driverNums.flatMap((d) => subsample(locationByDriver[d] ?? [], 300)).map((p) => ({ x: p.x, y: p.y }));
-              const t = buildTransform(allRaw);
-              if (!t) return null;
-              const { nx, ny } = t({ x: last.x, y: last.y });
+              const marker = driverMarkers[n];
+              if (!marker) return null;
               return (
                 <g key={`marker-${n}`}>
-                  <circle cx={nx} cy={ny} r={8} fill={driverColor(n)} stroke="var(--bg)" strokeWidth={2.5} />
-                  <text x={nx} y={ny + 4} textAnchor="middle" fontSize={6.5} fontWeight="bold" fill="white">
-                    {driverMap[n]?.name_acronym?.slice(0, 3) ?? '?'}
+                  <circle cx={marker.nx} cy={marker.ny} r={8} fill={driverColor(n)} stroke="var(--bg)" strokeWidth={2.5} />
+                  <text x={marker.nx} y={marker.ny + 4} textAnchor="middle" fontSize={6.5} fontWeight="bold" fill="white">
+                    {marker.label}
                   </text>
                 </g>
               );

--- a/src/hooks/useOpenF1.ts
+++ b/src/hooks/useOpenF1.ts
@@ -180,7 +180,7 @@ export function useDrivers(sessionKey: number | null) {
 }
 
 /** Only fetches if both sessionKey and driverNumber are valid positive numbers */
-export function useLaps(sessionKey: number | null, driverNumber: number | undefined) {
+export function useLaps(sessionKey: number | null, driverNumber: number | null | undefined) {
   const ok = sessionKey != null && driverNumber != null && driverNumber > 0;
   return useFetch<OpenF1Lap[]>(
     ok ? `laps:${sessionKey}:${driverNumber}` : null,
@@ -191,7 +191,7 @@ export function useLaps(sessionKey: number | null, driverNumber: number | undefi
 /** Telemetry for a specific lap, scoped by date window */
 export function useLapTelemetry(
   sessionKey: number | null,
-  driverNumber: number | undefined,
+  driverNumber: number | null | undefined,
   lapDateStart: string | null,
   nextLapDateStart: string | null | undefined,
 ) {
@@ -260,7 +260,7 @@ export function useIntervals(sessionKey: number | null) {
 
 export function useLapLocation(
   sessionKey: number | null,
-  driverNumber: number | undefined,
+  driverNumber: number | null | undefined,
   lapDateStart: string | null,
   nextLapDateStart: string | null | undefined,
 ) {


### PR DESCRIPTION
## Summary
- make the fixed dashboard driver slots explicit and reuse them across lap, telemetry, and location hooks
- rewrite position bucketing to use sorted driver samples with pointer-based bucket fills instead of repeated closest-sample scans
- memoize heavier derived data in Broadcast, Strategy, Radio, and Track Map views to avoid repeated recomputation