### PR TITLE
ui: design tokens for colors, mobile-responsive selectors, font loading

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -10,6 +10,12 @@
       content="f1stories.gr F1 telemetry dashboard with lap-by-lap analysis, comparison charts, and embeddable race coverage."
     />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;500;600;700;800;900&family=Rajdhani:wght@300;400;500;600;700&family=JetBrains+Mono:wght@300;400;500;600;700&display=swap"
+    />
     <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/

--- a/src/components/F1TelemetryDashboard.tsx
+++ b/src/components/F1TelemetryDashboard.tsx
@@ -3,6 +3,7 @@ import { useDashboardFilters } from '../hooks/useDashboardFilters';
 import type { DashboardFilterSnapshot } from '../hooks/useDashboardFilters';
 import { useDashboardSelectionData } from '../hooks/useDashboardSelectionData';
 import { useDashboardViewModel } from '../hooks/useDashboardViewModel';
+import { COLORS } from '../constants/colors';
 import {
   useDrivers,
   useIntervals,
@@ -25,7 +26,7 @@ import { DashboardTabs } from './dashboard/DashboardTabs';
 import { DriverSelector } from './dashboard/DriverSelector';
 import { TelemetryTab } from './dashboard/TelemetryTab';
 import { TrackMapTab } from './dashboard/TrackMapTab';
-import { Err } from './dashboard/shared';
+import { ChartSkeleton, Err } from './dashboard/shared';
 import type { Tab } from './dashboard/types';
 
 type ThemeMode = 'dark' | 'light';
@@ -70,7 +71,7 @@ const BroadcastTab = lazy(() => import('./dashboard/BroadcastTab').then((module)
 function TabLoadingPlaceholder({ label }: { label: string }) {
   return (
     <div className="dashboard-panel rounded-[16px] p-6 text-sm text-[color:var(--text-muted)] sm:rounded-[18px] sm:p-8">
-      {label}
+      <ChartSkeleton label={label} className="h-32" />
     </div>
   );
 }
@@ -152,7 +153,7 @@ function buildIframeSnippet(
   iframeHeight = 920,
 ) {
   const src = buildDashboardUrl(snapshot, splitMode, true, themeMode, anchorId);
-  const background = themeMode === 'light' ? '#ffffff' : '#111113';
+  const background = themeMode === 'light' ? COLORS.fallback.iframeLight : COLORS.fallback.iframeDark;
   return [
     `<iframe`,
     `  src="${src}"`,
@@ -412,7 +413,7 @@ export default function F1TelemetryDashboard() {
     root.classList.toggle('theme-light', themeMode === 'light');
     root.classList.toggle('theme-dark', themeMode === 'dark');
 
-    const themeColor = themeMode === 'light' ? '#ffffff' : '#111113';
+    const themeColor = themeMode === 'light' ? COLORS.fallback.iframeLight : COLORS.fallback.iframeDark;
     window.document.querySelector('meta[name="theme-color"]')?.setAttribute('content', themeColor);
 
     try {

--- a/src/components/dashboard/BroadcastTab.tsx
+++ b/src/components/dashboard/BroadcastTab.tsx
@@ -1,8 +1,9 @@
 import { useMemo } from 'react';
 import { Gauge, LayoutGrid, Timer, Tv2 } from 'lucide-react';
 import type { OpenF1Driver } from '../../api/openf1';
+import { COLORS } from '../../constants/colors';
 import type { DriverLapSummary, SectorRow } from './types';
-import { EmbedPanelButton, NoData, Panel, Spinner } from './shared';
+import { EmbedPanelButton, NoData, Panel, TableSkeleton } from './shared';
 import { fmtLap } from './utils';
 
 // ─── Sector Classification ─────────────────────────────────────────────────
@@ -10,9 +11,9 @@ import { fmtLap } from './utils';
 type SectorClass = 'purple' | 'green' | 'yellow' | 'none';
 
 const SECTOR_STYLE: Record<SectorClass, { text: string; bg: string }> = {
-  purple: { text: '#bf00ff', bg: 'rgba(191,0,255,0.18)' },
-  green:  { text: '#00c800', bg: 'rgba(0,200,0,0.16)' },
-  yellow: { text: '#ffc906', bg: 'rgba(255,201,6,0.16)' },
+  purple: { text: COLORS.sector.fastest, bg: COLORS.sector.fastestBg },
+  green:  { text: COLORS.sector.second, bg: COLORS.sector.secondBg },
+  yellow: { text: COLORS.sector.slower, bg: COLORS.sector.slowerBg },
   none:   { text: 'var(--text-muted)', bg: 'transparent' },
 };
 
@@ -98,7 +99,7 @@ function SpeedCell({ speed, isBest }: { speed: number | null | undefined; isBest
   return (
     <td
       className="bc-speed-cell"
-      style={isBest && speed != null ? { color: '#bf00ff', background: 'rgba(191,0,255,0.12)' } : undefined}
+      style={isBest && speed != null ? { color: COLORS.sector.fastest, background: COLORS.sector.fastestBgSoft } : undefined}
     >
       {speed != null ? `${speed.toFixed(0)} km/h` : '—'}
     </td>
@@ -173,7 +174,7 @@ export function BroadcastTab({
       >
         {lapSummaries.length === 0 ? (
           lapsLoading ? (
-            <Spinner label="Loading timing data…" />
+            <TableSkeleton rows={6} label="Loading timing data…" />
           ) : (
             <NoData msg="No lap data for the selected drivers." />
           )
@@ -272,7 +273,7 @@ export function BroadcastTab({
       >
         {!hasSectors ? (
           lapsLoading ? (
-            <Spinner label="Loading sector data…" />
+            <TableSkeleton rows={6} label="Loading sector data…" />
           ) : (
             <NoData msg="No sector data available for this lap." />
           )
@@ -321,9 +322,9 @@ export function BroadcastTab({
 
             {/* Sector color legend */}
             <div className="bc-sector-legend">
-              <span className="bc-sector-legend-item" style={{ color: '#bf00ff' }}>■ FASTEST</span>
-              <span className="bc-sector-legend-item" style={{ color: '#00c800' }}>■ 2ND FASTEST</span>
-              <span className="bc-sector-legend-item" style={{ color: '#ffc906' }}>■ SLOWER</span>
+              <span className="bc-sector-legend-item" style={{ color: COLORS.sector.fastest }}>■ FASTEST</span>
+              <span className="bc-sector-legend-item" style={{ color: COLORS.sector.second }}>■ 2ND FASTEST</span>
+              <span className="bc-sector-legend-item" style={{ color: COLORS.sector.slower }}>■ SLOWER</span>
             </div>
           </div>
         )}

--- a/src/components/dashboard/ChartPanel.tsx
+++ b/src/components/dashboard/ChartPanel.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState, type ReactNode } from 'react';
 import { Download, Expand, Shrink } from 'lucide-react';
+import { COLORS } from '../../constants/colors';
 import { EmbedPanelButton, Panel, ToolbarButton } from './shared';
 import { cn } from './utils';
 
@@ -114,7 +115,7 @@ function buildExportMarkup(svg: SVGSVGElement, legend: ChartLegendItem[], backgr
   exportSvg.setAttribute('height', String(totalHeight));
   exportSvg.setAttribute('viewBox', `0 0 ${width} ${totalHeight}`);
   exportSvg.setAttribute('fill', 'none');
-  exportSvg.setAttribute('color', getComputedStyle(document.documentElement).getPropertyValue('--text-strong').trim() || '#111113');
+  exportSvg.setAttribute('color', getComputedStyle(document.documentElement).getPropertyValue('--text-strong').trim() || COLORS.fallback.exportText);
 
   const backgroundRect = document.createElementNS(ns, 'rect');
   backgroundRect.setAttribute('x', '0');
@@ -193,7 +194,7 @@ export function ChartPanel({
     const chartSvg = chartRef.current?.querySelector('svg');
     if (!(chartSvg instanceof SVGSVGElement)) return;
 
-    const background = getComputedStyle(document.documentElement).getPropertyValue('--bg').trim() || '#111113';
+    const background = getComputedStyle(document.documentElement).getPropertyValue('--bg').trim() || COLORS.fallback.exportBackground;
     const markup = buildExportMarkup(chartSvg, legend, background);
     downloadSvg(`${sanitizeFilename(exportName)}.svg`, markup);
   };

--- a/src/components/dashboard/DashboardSelectors.tsx
+++ b/src/components/dashboard/DashboardSelectors.tsx
@@ -66,6 +66,7 @@ export function DashboardSelectors({
   const labelClass = embedMode
     ? 'mb-1.5 block text-[9px] uppercase tracking-[0.22em] text-[color:var(--text-dim)]'
     : 'mb-1.5 block text-[10px] uppercase tracking-[0.18em] text-[color:var(--text-dim)]';
+  const fieldClass = 'min-w-0 flex-[1_1_120px]';
   const displayQuickChips = embedMode ? quickChips.slice(0, 3) : quickChips;
   const summaryToneStyles = {
     blue: { color: 'var(--accent)' },
@@ -74,7 +75,7 @@ export function DashboardSelectors({
   } as const;
 
   const seasonField = (
-    <div>
+    <div className={fieldClass}>
       <label className={labelClass}>Season</label>
       <div className="relative">
         <select value={year} onChange={(event) => onYearChange(+event.target.value)} className="dashboard-select">
@@ -86,7 +87,7 @@ export function DashboardSelectors({
   );
 
   const circuitField = (
-    <div>
+    <div className={fieldClass}>
       <label className={labelClass}>Grand Prix</label>
       <div className="relative">
         <select value={circuit || ''} onChange={(event) => onCircuitChange(event.target.value)} disabled={!circuitOptions.length} className="dashboard-select">
@@ -100,7 +101,7 @@ export function DashboardSelectors({
   );
 
   const sessionField = (
-    <div>
+    <div className={fieldClass}>
       <label className={labelClass}>Session</label>
       <div className="relative">
         <select value={sessionKey || ''} onChange={(event) => onSessionChange(+event.target.value)} disabled={!sessionOptions.length} className="dashboard-select">
@@ -114,7 +115,7 @@ export function DashboardSelectors({
   );
 
   const lapSelectControl = (
-    <div className="relative flex-1">
+    <div className="relative min-w-0 flex-1">
       <select value={lapNum} onChange={(event) => onLapChange(+event.target.value)} disabled={!lapOptions.length} className="dashboard-select">
         {lapOptions.length === 0 && <option>Select drivers first</option>}
         {lapOptions.map((option) => <option key={option} value={option}>Lap {option}</option>)}
@@ -124,7 +125,7 @@ export function DashboardSelectors({
   );
 
   const lapField = (
-    <div>
+    <div className={fieldClass}>
       <label className={labelClass}>
         Lap {lapsLoading && <Loader2 size={10} className="ml-1 inline animate-spin" />}
       </label>
@@ -141,7 +142,7 @@ export function DashboardSelectors({
   );
 
   const lapSelectField = (
-    <div>
+    <div className={fieldClass}>
       <label className={labelClass}>
         Jump To Lap {lapsLoading && <Loader2 size={10} className="ml-1 inline animate-spin" />}
       </label>
@@ -209,7 +210,7 @@ export function DashboardSelectors({
               </div>
             )}
 
-            <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+            <div className="flex flex-wrap gap-3">
               {seasonField}
               {circuitField}
               {sessionField}
@@ -240,7 +241,7 @@ export function DashboardSelectors({
 
           <div className="mt-4">{lapField}</div>
 
-          <div className="mt-4 grid gap-3">
+          <div className="mt-4 flex flex-wrap gap-3">
             {seasonField}
             {circuitField}
             {sessionField}
@@ -280,7 +281,7 @@ export function DashboardSelectors({
                     Change season, session, and lap focus without losing comparison state.
                   </div>
                 </div>
-                <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+                <div className="flex flex-wrap gap-3">
                   {seasonField}
                   {circuitField}
                   {sessionField}

--- a/src/components/dashboard/EnergyTab.tsx
+++ b/src/components/dashboard/EnergyTab.tsx
@@ -3,7 +3,7 @@ import { Gauge, Zap } from 'lucide-react';
 import { Area, AreaChart, CartesianGrid, Line, LineChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
 import type { OpenF1Driver } from '../../api/openf1';
 import type { ComparisonPoint, DriverLapSummary, SpeedPoint } from './types';
-import { ChartTip, NoData, Spinner } from './shared';
+import { ChartSkeleton, ChartTip, NoData } from './shared';
 import { ChartPanel, type ChartLegendItem } from './ChartPanel';
 
 type Props = {
@@ -101,7 +101,7 @@ export function EnergyTab({
         embedMode={embedMode}
         onEmbedPanel={onEmbedPanel}
       >
-        {telemetryLoading ? <Spinner /> : comparisonMode ? (
+        {telemetryLoading ? <ChartSkeleton label="Loading DRS data..." className="h-[120px] sm:h-[160px]" /> : comparisonMode ? (
           <div className="h-[120px] sm:h-[160px]">
             <ResponsiveContainer width="100%" height="100%">
               <LineChart data={comparisonEnergyData}>
@@ -142,7 +142,7 @@ export function EnergyTab({
         embedMode={embedMode}
         onEmbedPanel={onEmbedPanel}
       >
-        {telemetryLoading ? <Spinner /> : comparisonMode ? (
+        {telemetryLoading ? <ChartSkeleton label="Loading gear trace..." className="h-[140px] sm:h-[180px]" /> : comparisonMode ? (
           <div className="h-[140px] sm:h-[180px]">
             <ResponsiveContainer width="100%" height="100%">
               <LineChart data={comparisonEnergyData}>
@@ -183,7 +183,7 @@ export function EnergyTab({
         embedMode={embedMode}
         onEmbedPanel={onEmbedPanel}
       >
-        {telemetryLoading ? <Spinner /> : comparisonMode ? (
+        {telemetryLoading ? <ChartSkeleton label="Loading RPM trace..." className="h-[140px] sm:h-[180px]" /> : comparisonMode ? (
           <div className="h-[140px] sm:h-[180px]">
             <ResponsiveContainer width="100%" height="100%">
               <LineChart data={comparisonEnergyData}>

--- a/src/components/dashboard/IncidentsTab.tsx
+++ b/src/components/dashboard/IncidentsTab.tsx
@@ -53,7 +53,7 @@ export function IncidentsTab({ loading, error, messages }: Props) {
                 className="dashboard-input w-full py-2 pl-9 pr-3 text-sm"
               />
             </div>
-            <div className="-mx-1 flex gap-2 overflow-x-auto px-1 pb-1 scrollbar-hide xl:mx-0 xl:flex-wrap xl:overflow-visible xl:px-0 xl:pb-0">
+            <div className="-mx-1 flex gap-2 overflow-x-auto px-1 pb-1 filter-scroll-fade xl:mx-0 xl:flex-wrap xl:overflow-visible xl:px-0 xl:pb-0">
               {filters.map((filter) => (
                 <button
                   key={filter}

--- a/src/components/dashboard/IntervalsTab.tsx
+++ b/src/components/dashboard/IntervalsTab.tsx
@@ -2,7 +2,8 @@ import { useMemo } from 'react';
 import { Gauge } from 'lucide-react';
 import { CartesianGrid, Line, LineChart, ReferenceLine, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
 import type { OpenF1Driver, OpenF1Interval } from '../../api/openf1';
-import { ChartTip, NoData, Panel, Spinner, Stat } from './shared';
+import { withAlpha } from '../../constants/colors';
+import { CardGridSkeleton, ChartSkeleton, ChartTip, NoData, Panel, Stat } from './shared';
 import { ChartPanel } from './ChartPanel';
 import type { ChartLegendItem } from './ChartPanel';
 
@@ -91,7 +92,31 @@ export function IntervalsTab({ driverNums, driverMap, intervals, intervalsLoadin
     [chartData, driverNums, driverMap, driverColor],
   );
 
-  if (intervalsLoading) return <Spinner label="Loading interval data…" />;
+  if (intervalsLoading) {
+    return (
+      <>
+        <Panel
+          title="Current Gaps"
+          icon={<Gauge size={14} style={{ color: 'var(--accent)' }} />}
+          sub="Loading latest interval samples"
+        >
+          <CardGridSkeleton count={8} label="Loading interval data..." />
+        </Panel>
+        <ChartPanel
+          title="Gap to Leader"
+          icon={<Gauge size={14} style={{ color: 'var(--accent)' }} />}
+          sub="Loading gap history"
+          exportName="gap-to-leader"
+          legend={legend}
+          panelId="intervals-gap-to-leader"
+          embedMode={embedMode}
+          onEmbedPanel={onEmbedPanel}
+        >
+          <ChartSkeleton label="Loading interval chart..." className="h-[200px] sm:h-[280px]" />
+        </ChartPanel>
+      </>
+    );
+  }
   if (!intervals || intervals.length === 0) {
     return (
       <Panel title="Intervals & Battles" icon={<Gauge size={14} style={{ color: 'var(--accent)' }} />}>
@@ -114,7 +139,7 @@ export function IntervalsTab({ driverNums, driverMap, intervals, intervalsLoadin
               <div
                 key={entry.driver_number}
                 className="dashboard-card rounded-[12px] p-3"
-                style={isSelected ? { borderColor: `${color}55` } : undefined}
+                style={isSelected ? { borderColor: withAlpha(color, 33) } : undefined}
               >
                 <div className="mb-1 text-[10px] uppercase tracking-[0.18em]" style={{ color }}>
                   {driverMap[entry.driver_number]?.name_acronym ?? `#${entry.driver_number}`}

--- a/src/components/dashboard/PositionsTab.tsx
+++ b/src/components/dashboard/PositionsTab.tsx
@@ -2,7 +2,8 @@ import { useMemo } from 'react';
 import { TrendingDown } from 'lucide-react';
 import { CartesianGrid, Line, LineChart, ReferenceLine, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
 import type { OpenF1Driver, OpenF1Position } from '../../api/openf1';
-import { ChartTip, NoData, Panel, Spinner } from './shared';
+import { teamColor, withAlpha } from '../../constants/colors';
+import { CardGridSkeleton, ChartSkeleton, ChartTip, NoData, Panel } from './shared';
 import { ChartPanel } from './ChartPanel';
 import type { ChartLegendItem } from './ChartPanel';
 
@@ -113,7 +114,31 @@ export function PositionsTab({ driverNums, driverMap, positions, positionsLoadin
       .slice(0, 20);
   }, [positions]);
 
-  if (positionsLoading) return <Spinner label="Loading race positions…" />;
+  if (positionsLoading) {
+    return (
+      <>
+        <Panel
+          title="Current Standings"
+          icon={<TrendingDown size={14} style={{ color: 'var(--accent)' }} />}
+          sub="Loading latest recorded positions"
+        >
+          <CardGridSkeleton count={10} label="Loading race positions..." />
+        </Panel>
+        <ChartPanel
+          title="Position History"
+          icon={<TrendingDown size={14} style={{ color: 'var(--accent-strong)' }} />}
+          sub="Loading position history"
+          exportName="position-history"
+          legend={legend}
+          panelId="positions-history"
+          embedMode={embedMode}
+          onEmbedPanel={onEmbedPanel}
+        >
+          <ChartSkeleton label="Loading position history..." className="h-[200px] sm:h-[280px]" />
+        </ChartPanel>
+      </>
+    );
+  }
   if (!positions || positions.length === 0) {
     return (
       <Panel title="Race Positions" icon={<TrendingDown size={14} style={{ color: 'var(--accent)' }} />}>
@@ -133,13 +158,13 @@ export function PositionsTab({ driverNums, driverMap, positions, positionsLoadin
         <div className="grid grid-cols-2 gap-2 sm:grid-cols-4 lg:grid-cols-5">
           {positionTable.map((entry) => {
             const driver = driverMap[entry.driver_number];
-            const color = driver ? `#${driver.team_colour}` : '#888';
+            const color = teamColor(driver?.team_colour);
             const isSelected = driverNums.includes(entry.driver_number);
             return (
               <div
                 key={entry.driver_number}
                 className="dashboard-card rounded-[12px] p-3"
-                style={isSelected ? { borderColor: `${color}55` } : undefined}
+                style={isSelected ? { borderColor: withAlpha(color, 33) } : undefined}
               >
                 <div className="mb-1 text-2xl font-black text-[color:var(--text-strong)]">
                   P{entry.position}

--- a/src/components/dashboard/StrategyTab.tsx
+++ b/src/components/dashboard/StrategyTab.tsx
@@ -1,19 +1,11 @@
 import { useMemo } from 'react';
 import { CircleDot, Timer } from 'lucide-react';
 import type { OpenF1Driver, OpenF1Pit, OpenF1Stint } from '../../api/openf1';
-import { EmbedPanelButton, NoData, Panel, Spinner } from './shared';
+import { COLORS, teamColor, withAlpha } from '../../constants/colors';
+import { CardGridSkeleton, EmbedPanelButton, NoData, Panel, TableSkeleton } from './shared';
 
 const COMPOUND_COLORS: Record<string, string> = {
-  SOFT: '#FF3333',
-  MEDIUM: '#FFC300',
-  HARD: '#EEEEEE',
-  INTERMEDIATE: '#43B02A',
-  WET: '#0067AD',
-  UNKNOWN: '#888',
-  HYPERSOFT: '#FF69B4',
-  ULTRASOFT: '#C800FF',
-  SUPERSOFT: '#FF3333',
-  TEST_UNKNOWN: '#888',
+  ...COLORS.compound,
 };
 
 type Props = {
@@ -84,7 +76,7 @@ export function StrategyTab({ lapNum, driverNums, driverMap, stintsLoading, stin
         return {
           driverNumber,
           acronym: driver.name_acronym,
-          teamColor: `#${driver.team_colour}`,
+          teamColor: teamColor(driver.team_colour),
           stintCount: driverStints.length,
           segments: driverStints.map((stint, index) => {
             const compound = (stint.compound || 'UNKNOWN').toUpperCase();
@@ -114,7 +106,7 @@ export function StrategyTab({ lapNum, driverNums, driverMap, stintsLoading, stin
         return {
           driverNumber,
           acronym: driver.name_acronym,
-          teamColor: `#${driver.team_colour}`,
+          teamColor: teamColor(driver.team_colour),
           compound,
           compoundColor: COMPOUND_COLORS[compound] || COMPOUND_COLORS.UNKNOWN,
           remaining: Math.max(0, activeStint.lap_end - lapNum),
@@ -128,11 +120,11 @@ export function StrategyTab({ lapNum, driverNums, driverMap, stintsLoading, stin
   const pitStopCards = useMemo<PitStopCard[]>(
     () => filteredPits.map((pit, index) => {
       const driver = driverMap[pit.driver_number];
-      const teamColor = `#${driver?.team_colour || '888'}`;
+      const pitTeamColor = teamColor(driver?.team_colour);
       return {
         key: `${pit.driver_number}-${pit.lap_number}-${pit.date}-${index}`,
         acronym: driver?.name_acronym || `#${pit.driver_number}`,
-        teamColor,
+        teamColor: pitTeamColor,
         stopDuration: pit.stop_duration?.toFixed(1) || '—',
         pitLaneDuration: pit.pit_duration?.toFixed(1) || '—',
         lapNumber: pit.lap_number,
@@ -150,7 +142,7 @@ export function StrategyTab({ lapNum, driverNums, driverMap, stintsLoading, stin
         panelId="strategy-tyre-strategy"
         headerRight={embedMode && onEmbedPanel ? <EmbedPanelButton onClick={() => onEmbedPanel('strategy-tyre-strategy')} /> : undefined}
       >
-        {stintsLoading ? <Spinner label="Loading stint data…" /> : strategyRows.length > 0 ? (
+        {stintsLoading ? <TableSkeleton rows={6} label="Loading stint data…" /> : strategyRows.length > 0 ? (
           <div className="space-y-3">
             {strategyRows.map((row) => (
               <div key={row.driverNumber} className="grid gap-2 sm:grid-cols-[64px_1fr_56px] sm:items-center sm:gap-4">
@@ -160,7 +152,7 @@ export function StrategyTab({ lapNum, driverNums, driverMap, stintsLoading, stin
                     <div
                       key={segment.key}
                       className="flex h-full min-w-[24px] items-center justify-center border-r border-[color:var(--line-strong)] text-[10px] font-bold"
-                      style={{ width: `${segment.width}%`, backgroundColor: `${segment.color}18`, color: segment.color }}
+                      style={{ width: `${segment.width}%`, backgroundColor: withAlpha(segment.color, 9), color: segment.color }}
                       title={segment.title}
                     >
                       {segment.compound.charAt(0)}
@@ -176,13 +168,13 @@ export function StrategyTab({ lapNum, driverNums, driverMap, stintsLoading, stin
       </Panel>
 
       <Panel title="Tyre Life Projection" icon={<CircleDot size={14} style={{ color: 'var(--accent-strong)' }} />} sub="Current stint context at the focused lap">
-        {tyreLifeCards.length > 0 ? (
+        {stintsLoading ? <CardGridSkeleton count={4} label="Loading tyre life projections..." /> : tyreLifeCards.length > 0 ? (
           <div className="grid gap-3 lg:grid-cols-2">
             {tyreLifeCards.map((card) => (
               <div key={card.driverNumber} className="dashboard-card rounded-[16px] p-4">
                 <div className="mb-3 flex items-center justify-between">
                   <span className="text-xs font-black tracking-[0.2em]" style={{ color: card.teamColor }}>{card.acronym}</span>
-                  <span className="rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.18em]" style={{ backgroundColor: `${card.compoundColor}1c`, color: card.compoundColor }}>{card.compound}</span>
+                  <span className="rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.18em]" style={{ backgroundColor: withAlpha(card.compoundColor, 11), color: card.compoundColor }}>{card.compound}</span>
                 </div>
                 <div className="mb-3 text-3xl font-black text-emerald-300">{card.remaining}</div>
                 <div className="grid grid-cols-3 gap-3 text-[10px] uppercase tracking-[0.16em] text-[color:var(--text-muted)]">
@@ -206,7 +198,7 @@ export function StrategyTab({ lapNum, driverNums, driverMap, stintsLoading, stin
       </Panel>
 
       <Panel title="Pit Stops" icon={<Timer size={14} style={{ color: 'var(--accent)' }} />} sub="Ordered by stationary time">
-        {pitsLoading ? <Spinner /> : pitStopCards.length > 0 ? (
+        {pitsLoading ? <CardGridSkeleton count={4} label="Loading pit stops..." /> : pitStopCards.length > 0 ? (
           <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4">
             {pitStopCards.map((card) => (
               <div key={card.key} className="dashboard-card rounded-[16px] p-3">

--- a/src/components/dashboard/TelemetryTab.tsx
+++ b/src/components/dashboard/TelemetryTab.tsx
@@ -2,8 +2,9 @@ import { useMemo } from 'react';
 import { Activity, Gauge, Timer, Trophy, Waves } from 'lucide-react';
 import { Area, CartesianGrid, ComposedChart, Line, LineChart, ReferenceLine, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
 import type { OpenF1Driver } from '../../api/openf1';
+import { COLORS } from '../../constants/colors';
 import type { ComparisonPoint, DriverLapSummary, SectorRow, SpeedPoint } from './types';
-import { ChartTip, EmbedPanelButton, NoData, Panel, Spinner } from './shared';
+import { ChartSkeleton, ChartTip, EmbedPanelButton, NoData, Panel, TableSkeleton } from './shared';
 import { ChartPanel, type ChartLegendItem } from './ChartPanel';
 import { fmtLap } from './utils';
 
@@ -83,8 +84,8 @@ export function TelemetryTab({
       ];
     })
     : [
-      { label: 'Throttle', color: '#22C55E', variant: 'area' as const },
-      { label: 'Brake', color: '#EF4444', variant: 'area' as const },
+      { label: 'Throttle', color: COLORS.success, variant: 'area' as const },
+      { label: 'Brake', color: COLORS.danger, variant: 'area' as const },
     ];
   const speedDeltaData = useMemo(() => {
     if (comparisonSpeedData.length === 0) return [];
@@ -189,7 +190,7 @@ export function TelemetryTab({
                     <div className="flex h-6">
                       <div className="flex items-center justify-center text-[10px] font-bold text-white" style={{ width: `${s1Width}%`, backgroundColor: 'var(--accent)' }}>{row.s1?.toFixed(3) ?? '—'}</div>
                       <div className="flex items-center justify-center text-[10px] font-bold text-white" style={{ width: `${s2Width}%`, backgroundColor: 'var(--accent-strong)' }}>{row.s2?.toFixed(3) ?? '—'}</div>
-                      <div className="flex items-center justify-center text-[10px] font-bold text-white" style={{ width: `${s3Width}%`, backgroundColor: '#1AA34A' }}>{row.s3?.toFixed(3) ?? '—'}</div>
+                      <div className="flex items-center justify-center text-[10px] font-bold text-white" style={{ width: `${s3Width}%`, backgroundColor: COLORS.sector.three }}>{row.s3?.toFixed(3) ?? '—'}</div>
                     </div>
                   </div>
                   <div className="hidden text-right text-sm font-black font-mono text-[color:var(--text-soft)] md:block">{fmtLap(row.total ?? null)}</div>
@@ -197,7 +198,7 @@ export function TelemetryTab({
               );
             })}
           </div>
-        ) : lapsLoading ? <Spinner label="Building sector split..." /> : <NoData msg="No sector comparison available for this lap." />}
+        ) : lapsLoading ? <TableSkeleton rows={4} label="Building sector split..." /> : <NoData msg="No sector comparison available for this lap." />}
       </Panel>
 
       <Panel title="Sector Times" icon={<Timer size={14} style={{ color: 'var(--accent-strong)' }} />} sub={`Lap ${lapNum} — sector benchmark against selected drivers`}>
@@ -225,7 +226,7 @@ export function TelemetryTab({
                       <span style={bestS2 != null && row.s2 != null && row.s2 <= bestS2 ? { color: 'var(--accent-strong)' } : undefined}>{row.s2?.toFixed(3) ?? '—'}</span>
                     </td>
                     <td className="py-2 text-right font-mono text-xs text-[color:var(--text-soft)]">
-                      <span style={bestS3 != null && row.s3 != null && row.s3 <= bestS3 ? { color: '#1AA34A' } : undefined}>{row.s3?.toFixed(3) ?? '—'}</span>
+                      <span style={bestS3 != null && row.s3 != null && row.s3 <= bestS3 ? { color: COLORS.sector.three } : undefined}>{row.s3?.toFixed(3) ?? '—'}</span>
                     </td>
                     <td className="py-2 text-right text-xs font-bold font-mono text-[color:var(--text-strong)]">{fmtLap(row.total ?? null)}</td>
                     <td className="py-2 text-right font-mono text-xs text-[color:var(--accent-strong)]">{summary?.gapToLeader != null ? `+${summary.gapToLeader.toFixed(3)}` : '—'}</td>
@@ -235,7 +236,7 @@ export function TelemetryTab({
               })}</tbody>
             </table>
           </div>
-        ) : lapsLoading ? <Spinner label="Loading lap data..." /> : <NoData msg="No sector times for this lap. Try a different lap number." />}
+        ) : lapsLoading ? <TableSkeleton rows={6} label="Loading lap data..." /> : <NoData msg="No sector times for this lap. Try a different lap number." />}
       </Panel>
 
       <ChartPanel
@@ -251,7 +252,7 @@ export function TelemetryTab({
         embedMode={embedMode}
         onEmbedPanel={onEmbedPanel}
       >
-        {telemetryLoading ? <Spinner label="Fetching car telemetry..." /> : telemetryError ? <NoData msg={telemetryError} /> : comparisonSpeedData.length > 0 ? (
+        {telemetryLoading ? <ChartSkeleton label="Fetching car telemetry..." className="h-[200px] sm:h-[260px]" /> : telemetryError ? <NoData msg={telemetryError} /> : comparisonSpeedData.length > 0 ? (
           <div className="h-[200px] sm:h-[260px]">
             <ResponsiveContainer width="100%" height="100%">
               <LineChart data={comparisonSpeedData}>
@@ -346,8 +347,8 @@ export function TelemetryTab({
                   <YAxis domain={[-110, 110]} tick={{ fill: chartAxis, fontSize: 10 }} stroke={chartGrid} tickFormatter={(value: number) => `${Math.abs(value)}%`} />
                   <ReferenceLine y={0} stroke={chartReference} strokeDasharray="4 4" />
                   <Tooltip content={<ChartTip />} />
-                  <Area type="monotone" dataKey="throttle" stroke="#22C55E" fill="#22C55E" fillOpacity={0.08} strokeWidth={1.5} isAnimationActive={false} name="Throttle %" />
-                  <Area type="monotone" dataKey="brake" stroke="#EF4444" fill="#EF4444" fillOpacity={0.08} strokeWidth={1.5} isAnimationActive={false} name="Brake" />
+                  <Area type="monotone" dataKey="throttle" stroke={COLORS.success} fill={COLORS.success} fillOpacity={0.08} strokeWidth={1.5} isAnimationActive={false} name="Throttle %" />
+                  <Area type="monotone" dataKey="brake" stroke={COLORS.danger} fill={COLORS.danger} fillOpacity={0.08} strokeWidth={1.5} isAnimationActive={false} name="Brake" />
                 </ComposedChart>
               </ResponsiveContainer>
             </div>
@@ -356,7 +357,7 @@ export function TelemetryTab({
       )}
 
       <ChartPanel title="Lap Times Comparison" icon={<Timer size={14} style={{ color: 'var(--accent-strong)' }} />} sub={lapsLoading ? 'Loading lap data...' : `${driverNums.map((num) => driverMap[num]?.name_acronym).filter(Boolean).join(' vs ')} — excludes pit out-laps`} className="overflow-hidden" exportName="lap-times-comparison" legend={driverLegend} panelId="telemetry-lap-times" embedMode={embedMode} onEmbedPanel={onEmbedPanel}>
-        {lapsLoading ? <Spinner /> : lapTimeData.some((point) => Object.keys(point).length > 1) ? (
+        {lapsLoading ? <ChartSkeleton label="Loading lap time data..." className="h-[180px] sm:h-[220px]" /> : lapTimeData.some((point) => Object.keys(point).length > 1) ? (
           <div className="h-[180px] sm:h-[220px]">
             <ResponsiveContainer width="100%" height="100%">
               <LineChart data={lapTimeData}>
@@ -374,7 +375,7 @@ export function TelemetryTab({
       </ChartPanel>
 
       <ChartPanel title="Gap To Best Lap" icon={<Timer size={14} style={{ color: 'var(--accent)' }} />} sub="Per-lap delta to the fastest selected driver on that same lap" className="overflow-hidden" exportName="gap-to-best-lap" legend={driverLegend} panelId="telemetry-gap-best" embedMode={embedMode} onEmbedPanel={onEmbedPanel}>
-        {lapsLoading ? <Spinner /> : lapDeltaData.some((point) => Object.keys(point).length > 1) ? (
+        {lapsLoading ? <ChartSkeleton label="Loading gap trend data..." className="h-[160px] sm:h-[200px]" /> : lapDeltaData.some((point) => Object.keys(point).length > 1) ? (
           <div className="h-[160px] sm:h-[200px]">
             <ResponsiveContainer width="100%" height="100%">
               <LineChart data={lapDeltaData}>

--- a/src/components/dashboard/TrackMapTab.tsx
+++ b/src/components/dashboard/TrackMapTab.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from 'react';
 import { Map } from 'lucide-react';
 import type { OpenF1Driver, OpenF1Location } from '../../api/openf1';
-import { EmbedPanelButton, NoData, Panel, Spinner } from './shared';
+import { ChartSkeleton, EmbedPanelButton, NoData, Panel } from './shared';
 
 type Props = {
   lapNum: number;
@@ -116,7 +116,13 @@ export function TrackMapTab({ lapNum, driverNums, driverMap, locationByDriver, l
     return `Track map for lap ${lapNum}. Drivers: ${describedDrivers}. Lines show each driver's GPS path around the circuit.`;
   }, [activeDrivers, driverMap, driverNums, lapNum]);
 
-  if (locationLoading) return <Spinner label="Fetching GPS location data…" />;
+  if (locationLoading) {
+    return (
+      <Panel title={`Track Map — Lap ${lapNum}`} icon={<Map size={14} style={{ color: 'var(--accent)' }} />} sub="Fetching GPS location data">
+        <ChartSkeleton label="Fetching GPS location data..." className="h-[260px] sm:h-[360px]" />
+      </Panel>
+    );
+  }
   if (!trackPolyline) {
     return (
       <Panel title={`Track Map — Lap ${lapNum}`} icon={<Map size={14} style={{ color: 'var(--accent)' }} />}>
@@ -136,10 +142,12 @@ export function TrackMapTab({ lapNum, driverNums, driverMap, locationByDriver, l
         panelId="trackmap-lap-map"
         headerRight={embedMode && onEmbedPanel ? <EmbedPanelButton onClick={() => onEmbedPanel('trackmap-lap-map')} /> : undefined}
       >
-        <div className="overflow-x-auto">
+        <div className="h-[260px] overflow-x-auto sm:h-[380px]">
           <svg
             viewBox={`0 0 ${MAP_W} ${MAP_H}`}
             width="100%"
+            height="100%"
+            preserveAspectRatio="xMidYMid meet"
             style={{ maxWidth: MAP_W, display: 'block', margin: '0 auto' }}
             aria-label={svgLabel}
             role="img"

--- a/src/components/dashboard/WeatherTab.tsx
+++ b/src/components/dashboard/WeatherTab.tsx
@@ -1,8 +1,9 @@
 import { Sun } from 'lucide-react';
 import { CartesianGrid, Line, LineChart, PolarAngleAxis, PolarGrid, Radar, RadarChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
 import type { OpenF1Weather } from '../../api/openf1';
+import { COLORS } from '../../constants/colors';
 import type { WeatherRadarPoint, WeatherTrendPoint } from './types';
-import { ChartTip, Err, NoData, Spinner, Stat } from './shared';
+import { CardGridSkeleton, ChartSkeleton, ChartTip, Err, NoData, Stat } from './shared';
 import { ChartPanel } from './ChartPanel';
 
 type Props = {
@@ -17,24 +18,41 @@ type Props = {
 };
 
 export function WeatherTab({ loading, error, latestWeather, sampleCount, weatherRadar, weatherTrend, embedMode = false, onEmbedPanel }: Props) {
-  if (loading) return <Spinner />;
-  if (error) return <Err msg={error} />;
-  if (!latestWeather) return <NoData msg="No weather data for this session." />;
   const chartGrid = 'var(--chart-grid)';
   const chartAxis = 'var(--chart-axis)';
   const chartAxisSoft = 'var(--chart-axis-soft)';
+  const weatherLegend = [
+    { label: 'Air °C', color: COLORS.weather.air },
+    { label: 'Track °C', color: COLORS.weather.track },
+    { label: 'Humidity %', color: COLORS.weather.humidity },
+    { label: 'Wind m/s', color: COLORS.weather.wind },
+  ];
+
+  if (loading) {
+    return (
+      <>
+        <CardGridSkeleton count={4} label="Loading weather readings..." />
+        <CardGridSkeleton count={4} label="Loading weather summary..." />
+        <ChartPanel title="Conditions Trend" icon={<Sun size={14} style={{ color: 'var(--accent-strong)' }} />} sub="Loading session weather samples" exportName="conditions-trend" legend={weatherLegend} panelId="weather-trend" embedMode={embedMode} onEmbedPanel={onEmbedPanel}>
+          <ChartSkeleton label="Loading weather chart..." className="h-[180px] sm:h-[260px]" />
+        </ChartPanel>
+      </>
+    );
+  }
+  if (error) return <Err msg={error} />;
+  if (!latestWeather) return <NoData msg="No weather data for this session." />;
 
   return (
     <>
       <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
-        <Stat label="Air Temperature" value={latestWeather.air_temperature.toFixed(1)} unit="°C" color="#EF4444" />
-        <Stat label="Track Temperature" value={latestWeather.track_temperature.toFixed(1)} unit="°C" color="#F97316" />
-        <Stat label="Humidity" value={latestWeather.humidity.toFixed(0)} unit="%" color="#3B82F6" />
-        <Stat label="Wind Speed" value={latestWeather.wind_speed.toFixed(1)} unit="m/s" color="#06B6D4" />
+        <Stat label="Air Temperature" value={latestWeather.air_temperature.toFixed(1)} unit="°C" color={COLORS.weather.air} />
+        <Stat label="Track Temperature" value={latestWeather.track_temperature.toFixed(1)} unit="°C" color={COLORS.weather.track} />
+        <Stat label="Humidity" value={latestWeather.humidity.toFixed(0)} unit="%" color={COLORS.weather.humidity} />
+        <Stat label="Wind Speed" value={latestWeather.wind_speed.toFixed(1)} unit="m/s" color={COLORS.weather.wind} />
       </div>
       <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
         <Stat label="Pressure" value={latestWeather.pressure.toFixed(0)} unit="mbar" />
-        <Stat label="Rainfall" value={latestWeather.rainfall ? 'Yes' : 'No'} color={latestWeather.rainfall ? '#3B82F6' : '#22C55E'} />
+        <Stat label="Rainfall" value={latestWeather.rainfall ? 'Yes' : 'No'} color={latestWeather.rainfall ? COLORS.weather.humidity : COLORS.success} />
         <Stat label="Wind Direction" value={latestWeather.wind_direction.toFixed(0)} unit="°" />
         <Stat label="Weather Samples" value={sampleCount} />
       </div>
@@ -49,7 +67,7 @@ export function WeatherTab({ loading, error, latestWeather, sampleCount, weather
           </ResponsiveContainer>
         </div>
       </ChartPanel>
-      <ChartPanel title="Conditions Trend" icon={<Sun size={14} style={{ color: 'var(--accent-strong)' }} />} sub="Downsampled timeline across the current session" exportName="conditions-trend" legend={[{ label: 'Air °C', color: '#EF4444' }, { label: 'Track °C', color: '#F97316' }, { label: 'Humidity %', color: '#3B82F6' }, { label: 'Wind m/s', color: '#06B6D4' }]} panelId="weather-trend" embedMode={embedMode} onEmbedPanel={onEmbedPanel}>
+      <ChartPanel title="Conditions Trend" icon={<Sun size={14} style={{ color: 'var(--accent-strong)' }} />} sub="Downsampled timeline across the current session" exportName="conditions-trend" legend={weatherLegend} panelId="weather-trend" embedMode={embedMode} onEmbedPanel={onEmbedPanel}>
         {weatherTrend.length > 1 ? (
           <div className="h-[180px] sm:h-[260px]">
             <ResponsiveContainer width="100%" height="100%">
@@ -59,10 +77,10 @@ export function WeatherTab({ loading, error, latestWeather, sampleCount, weather
                 <YAxis yAxisId="temp" tick={{ fill: chartAxis, fontSize: 10 }} stroke={chartGrid} />
                 <YAxis yAxisId="aux" orientation="right" tick={{ fill: chartAxisSoft, fontSize: 9 }} stroke={chartGrid} />
                 <Tooltip content={<ChartTip />} />
-                <Line yAxisId="temp" type="monotone" dataKey="air" stroke="#EF4444" strokeWidth={2} dot={false} isAnimationActive={false} name="Air °C" />
-                <Line yAxisId="temp" type="monotone" dataKey="track" stroke="#F97316" strokeWidth={2} dot={false} isAnimationActive={false} name="Track °C" />
-                <Line yAxisId="aux" type="monotone" dataKey="humidity" stroke="#3B82F6" strokeWidth={1.6} dot={false} isAnimationActive={false} name="Humidity %" />
-                <Line yAxisId="aux" type="monotone" dataKey="wind" stroke="#06B6D4" strokeWidth={1.6} dot={false} isAnimationActive={false} name="Wind m/s" />
+                <Line yAxisId="temp" type="monotone" dataKey="air" stroke={COLORS.weather.air} strokeWidth={2} dot={false} isAnimationActive={false} name="Air °C" />
+                <Line yAxisId="temp" type="monotone" dataKey="track" stroke={COLORS.weather.track} strokeWidth={2} dot={false} isAnimationActive={false} name="Track °C" />
+                <Line yAxisId="aux" type="monotone" dataKey="humidity" stroke={COLORS.weather.humidity} strokeWidth={1.6} dot={false} isAnimationActive={false} name="Humidity %" />
+                <Line yAxisId="aux" type="monotone" dataKey="wind" stroke={COLORS.weather.wind} strokeWidth={1.6} dot={false} isAnimationActive={false} name="Wind m/s" />
               </LineChart>
             </ResponsiveContainer>
           </div>

--- a/src/components/dashboard/shared.tsx
+++ b/src/components/dashboard/shared.tsx
@@ -2,10 +2,68 @@ import type { ReactNode } from 'react';
 import type { NameType, ValueType } from 'recharts/types/component/DefaultTooltipContent';
 import { AlertTriangle, Code2, Loader2 } from 'lucide-react';
 import type { OpenF1Driver } from '../../api/openf1';
+import { COLORS, teamColor, withAlpha } from '../../constants/colors';
 import { cn } from './utils';
 
 export function Spinner({ label }: { label?: string }) {
   return <div className="flex items-center justify-center gap-2 py-10 text-sm text-[color:var(--text-muted)]"><Loader2 size={16} className="animate-spin" />{label || 'Loading…'}</div>;
+}
+
+export function SkeletonBlock({ className }: { className?: string }) {
+  return <div className={cn('animate-pulse rounded-[12px] bg-[color:var(--surface-soft)]', className)} />;
+}
+
+export function ChartSkeleton({ label = 'Loading chart…', className }: { label?: string; className?: string }) {
+  const bars = [34, 62, 46, 78, 55, 88, 50, 70];
+  return (
+    <div
+      role="status"
+      aria-label={label}
+      className={cn('rounded-[14px] border border-[color:var(--line)] bg-[color:var(--surface-soft-2)] p-4', className)}
+    >
+      <div className="flex h-full min-h-[120px] items-end gap-2">
+        {bars.map((height, index) => (
+          <div
+            key={index}
+            className="flex-1 animate-pulse rounded-t-[8px] bg-[color:var(--surface-soft)]"
+            style={{ height: `${height}%`, animationDelay: `${index * 70}ms` }}
+          />
+        ))}
+      </div>
+      <span className="sr-only">{label}</span>
+    </div>
+  );
+}
+
+export function CardGridSkeleton({ count = 4, label = 'Loading cards…' }: { count?: number; label?: string }) {
+  return (
+    <div role="status" aria-label={label} className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+      {Array.from({ length: count }, (_, index) => (
+        <div key={index} className="dashboard-card rounded-[14px] p-3">
+          <SkeletonBlock className="mb-3 h-3 w-16" />
+          <SkeletonBlock className="mb-2 h-7 w-20" />
+          <SkeletonBlock className="h-2.5 w-full" />
+        </div>
+      ))}
+      <span className="sr-only">{label}</span>
+    </div>
+  );
+}
+
+export function TableSkeleton({ rows = 5, label = 'Loading rows…' }: { rows?: number; label?: string }) {
+  return (
+    <div role="status" aria-label={label} className="space-y-2">
+      <SkeletonBlock className="h-4 w-36" />
+      {Array.from({ length: rows }, (_, index) => (
+        <div key={index} className="grid grid-cols-[54px_minmax(0,1fr)_72px] items-center gap-3">
+          <SkeletonBlock className="h-4 w-full" />
+          <SkeletonBlock className="h-6 w-full" />
+          <SkeletonBlock className="h-4 w-full" />
+        </div>
+      ))}
+      <span className="sr-only">{label}</span>
+    </div>
+  );
 }
 
 export function Err({ msg }: { msg: string }) {
@@ -72,7 +130,7 @@ export function DriverChip({
   compact?: boolean;
   stacked?: boolean;
 }) {
-  const color = `#${driver.team_colour || '888'}`;
+  const color = teamColor(driver.team_colour);
   const initials = driver.name_acronym.slice(0, 3);
 
   if (stacked) {
@@ -85,7 +143,7 @@ export function DriverChip({
             ? 'text-[color:var(--text-strong)] shadow-[0_8px_18px_-16px_rgba(0,0,0,0.28)]'
             : 'border-[color:var(--line)] bg-[color:var(--surface-soft-2)] text-[color:var(--text-soft)] hover:border-[color:var(--line-strong)] hover:bg-[color:var(--surface-soft)]',
         )}
-        style={selected ? { borderColor: `${color}88`, background: `linear-gradient(180deg, ${color}20, transparent 78%), var(--surface-card)` } : {}}
+        style={selected ? { borderColor: withAlpha(color, 53), background: `linear-gradient(180deg, ${withAlpha(color, 12)}, transparent 78%), var(--surface-card)` } : {}}
       >
         <span className="absolute inset-x-0 top-0 h-px rounded-t-[14px]" style={{ backgroundColor: color, opacity: selected ? 0.9 : 0.55 }} />
         <div className="flex w-full items-start justify-between gap-2">
@@ -103,7 +161,7 @@ export function DriverChip({
                 ? 'bg-white/10'
                 : 'border-[color:var(--line)] bg-[color:var(--surface-soft)] text-[color:var(--text-dim)] group-hover:border-[color:var(--line-strong)] group-hover:text-[color:var(--text-muted)]',
             )}
-            style={selected ? { borderColor: `${color}88`, color } : undefined}
+            style={selected ? { borderColor: withAlpha(color, 53), color } : undefined}
           >
             #{driver.driver_number}
           </span>
@@ -134,7 +192,7 @@ export function DriverChip({
           ? 'border-current bg-[color:var(--surface-soft)] text-[color:var(--text-strong)] shadow-[0_0_0_1px_currentColor_inset]'
           : 'border-[color:var(--line)] text-[color:var(--text-muted)] hover:border-[color:var(--line-strong)] hover:bg-[color:var(--surface-soft)] hover:text-[color:var(--text-soft)]',
       )}
-      style={selected ? { color, borderColor: `${color}99`, background: `${color}10` } : {}}
+      style={selected ? { color, borderColor: withAlpha(color, 60), background: withAlpha(color, 6) } : {}}
     >
       <span className={cn(
         'relative flex shrink-0 items-center justify-center overflow-hidden rounded-full border border-[color:var(--line-strong)] bg-[color:var(--surface-avatar)] font-black text-[color:var(--text-soft)]',
@@ -146,7 +204,7 @@ export function DriverChip({
           initials
         )}
       </span>
-      <span className="h-1.5 w-1.5 rounded-full" style={{ backgroundColor: selected ? color : '#4b5563' }} />
+      <span className="h-1.5 w-1.5 rounded-full" style={{ backgroundColor: selected ? color : COLORS.mutedDot }} />
       <span className={cn(compact ? 'tracking-[0.12em]' : 'tracking-[0.14em]')}>{driver.name_acronym}</span>
       <span className={cn('font-normal opacity-50', compact ? 'text-[9px]' : 'text-[10px]')}>#{driver.driver_number}</span>
     </button>

--- a/src/constants/colors.ts
+++ b/src/constants/colors.ts
@@ -1,0 +1,50 @@
+export const COLORS = {
+  fallback: {
+    exportText: '#ffffff',
+    exportBackground: '#111113',
+    iframeLight: '#ffffff',
+    iframeDark: '#111113',
+  },
+  driverFallback: 'var(--color-driver-fallback)',
+  mutedDot: 'var(--color-muted-dot)',
+  danger: 'var(--color-danger)',
+  success: 'var(--color-success)',
+  warning: 'var(--color-warning)',
+  weather: {
+    air: 'var(--color-weather-air)',
+    track: 'var(--color-weather-track)',
+    humidity: 'var(--color-weather-humidity)',
+    wind: 'var(--color-weather-wind)',
+  },
+  sector: {
+    fastest: 'var(--color-sector-fastest)',
+    fastestBg: 'var(--color-sector-fastest-bg)',
+    fastestBgSoft: 'var(--color-sector-fastest-bg-soft)',
+    second: 'var(--color-sector-second)',
+    secondBg: 'var(--color-sector-second-bg)',
+    slower: 'var(--color-sector-slower)',
+    slowerBg: 'var(--color-sector-slower-bg)',
+    three: 'var(--color-sector-three)',
+  },
+  compound: {
+    SOFT: 'var(--color-compound-soft)',
+    MEDIUM: 'var(--color-compound-medium)',
+    HARD: 'var(--color-compound-hard)',
+    INTERMEDIATE: 'var(--color-compound-intermediate)',
+    WET: 'var(--color-compound-wet)',
+    UNKNOWN: 'var(--color-compound-unknown)',
+    HYPERSOFT: 'var(--color-compound-hypersoft)',
+    ULTRASOFT: 'var(--color-compound-ultrasoft)',
+    SUPERSOFT: 'var(--color-compound-supersoft)',
+    TEST_UNKNOWN: 'var(--color-compound-unknown)',
+  },
+} as const;
+
+export function withAlpha(color: string, percent: number) {
+  return `color-mix(in srgb, ${color} ${percent}%, transparent)`;
+}
+
+export function teamColor(teamColour?: string | null) {
+  const normalized = teamColour?.trim().replace(/^#/, '');
+  return normalized ? `#${normalized}` : COLORS.driverFallback;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -59,6 +59,32 @@
   --chart-axis-soft: #515157;
   --chart-rpm: rgba(255, 255, 255, 0.16);
   --chart-reference: rgba(255, 255, 255, 0.12);
+  --color-driver-fallback: #888888;
+  --color-muted-dot: #4b5563;
+  --color-danger: #ef4444;
+  --color-success: #22c55e;
+  --color-warning: #f97316;
+  --color-weather-air: #ef4444;
+  --color-weather-track: #f97316;
+  --color-weather-humidity: #3b82f6;
+  --color-weather-wind: #06b6d4;
+  --color-sector-fastest: #bf00ff;
+  --color-sector-fastest-bg: rgba(191, 0, 255, 0.18);
+  --color-sector-fastest-bg-soft: rgba(191, 0, 255, 0.12);
+  --color-sector-second: #00c800;
+  --color-sector-second-bg: rgba(0, 200, 0, 0.16);
+  --color-sector-slower: #ffc906;
+  --color-sector-slower-bg: rgba(255, 201, 6, 0.16);
+  --color-sector-three: #1aa34a;
+  --color-compound-soft: #ff3333;
+  --color-compound-medium: #ffc300;
+  --color-compound-hard: #eeeeee;
+  --color-compound-intermediate: #43b02a;
+  --color-compound-wet: #0067ad;
+  --color-compound-unknown: #888888;
+  --color-compound-hypersoft: #ff69b4;
+  --color-compound-ultrasoft: #c800ff;
+  --color-compound-supersoft: #ff3333;
 }
 
 .theme-light {
@@ -120,6 +146,8 @@
   --chart-axis-soft: #a1a1a6;
   --chart-rpm: rgba(17, 17, 19, 0.16);
   --chart-reference: rgba(29, 29, 31, 0.14);
+  --color-driver-fallback: #6e6e73;
+  --color-muted-dot: #86868b;
 }
 
 .theme-dark {
@@ -243,6 +271,7 @@ code, .font-mono {
 
 .dashboard-select {
   width: 100%;
+  min-height: 44px;
   cursor: pointer;
   appearance: none;
   border-radius: 6px;
@@ -253,6 +282,11 @@ code, .font-mono {
   color: var(--text-soft);
   outline: none;
   transition: border-color 120ms ease, color 120ms ease;
+}
+
+.filter-scroll-fade {
+  -webkit-mask-image: linear-gradient(to right, #000 calc(100% - 2rem), transparent);
+  mask-image: linear-gradient(to right, #000 calc(100% - 2rem), transparent);
 }
 
 .dashboard-select:hover,
@@ -363,6 +397,11 @@ select {
   .dashboard-toolbar {
     justify-content: flex-end;
     align-self: flex-end;
+  }
+
+  .filter-scroll-fade {
+    -webkit-mask-image: none;
+    mask-image: none;
   }
 }
 


### PR DESCRIPTION
## Summary
- add semantic color constants and CSS tokens for chart/status colors
- improve selector wrapping, incident filter overflow affordance, track map SVG aspect ratio, and export/embed fallbacks
- add reusable skeleton loading states for chart-heavy dashboard tabs

## Verification
- npm run typecheck
- npm run lint
- npm run build