### PR TITLE
feat: error boundaries, retry UI, input validation guards

### DIFF
--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,0 +1,49 @@
+import { Component, type ErrorInfo, type ReactNode } from 'react';
+
+type Props = {
+  children: ReactNode;
+  label: string;
+  resetKey?: string | number;
+};
+
+type State = {
+  error: Error | null;
+};
+
+export class ErrorBoundary extends Component<Props, State> {
+  state: State = { error: null };
+
+  static getDerivedStateFromError(error: Error): State {
+    return { error };
+  }
+
+  componentDidUpdate(prevProps: Props) {
+    if (this.state.error && prevProps.resetKey !== this.props.resetKey) {
+      this.setState({ error: null });
+    }
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    console.warn(`[ErrorBoundary] ${this.props.label}`, error, info.componentStack);
+  }
+
+  render() {
+    if (!this.state.error) return this.props.children;
+
+    return (
+      <div className="dashboard-panel flex flex-col items-center justify-center gap-4 rounded-[16px] p-8 text-center sm:rounded-[18px]">
+        <div>
+          <p className="text-sm font-semibold text-red-300">Failed to render {this.props.label}.</p>
+          <p className="mt-1 text-xs text-[color:var(--text-muted)]">{this.state.error.message || 'Unexpected render error'}</p>
+        </div>
+        <button
+          type="button"
+          onClick={() => this.setState({ error: null })}
+          className="rounded-[10px] border border-[color:var(--accent-border)] bg-[color:var(--accent-muted)] px-3 py-2 text-xs font-semibold uppercase tracking-[0.14em] text-[color:var(--accent)] transition-colors hover:text-[color:var(--accent-hover)]"
+        >
+          Retry
+        </button>
+      </div>
+    );
+  }
+}

--- a/src/components/F1TelemetryDashboard.tsx
+++ b/src/components/F1TelemetryDashboard.tsx
@@ -19,6 +19,7 @@ import {
   useTeamRadio,
   useWeather,
 } from '../hooks/useOpenF1';
+import { ErrorBoundary } from './ErrorBoundary';
 import { DashboardHeader } from './dashboard/DashboardHeader';
 import { DashboardSelectors } from './dashboard/DashboardSelectors';
 import { DashboardTabs } from './dashboard/DashboardTabs';
@@ -163,6 +164,18 @@ function buildIframeSnippet(
     `  style="border:0; width:100%; max-width:100%; background:${background};"`,
     `></iframe>`,
   ].join('\n');
+}
+
+function getClipboardErrorMessage(error: unknown, label: string) {
+  const isDomException = typeof DOMException !== 'undefined' && error instanceof DOMException;
+  if (isDomException && (error.name === 'NotAllowedError' || error.name === 'SecurityError')) {
+    return `${label} clipboard denied; copy manually`;
+  }
+  return `${label} could not be copied; copy manually`;
+}
+
+function isShareCancel(error: unknown) {
+  return typeof DOMException !== 'undefined' && error instanceof DOMException && error.name === 'AbortError';
 }
 
 export default function F1TelemetryDashboard() {
@@ -357,6 +370,7 @@ export default function F1TelemetryDashboard() {
   const pageShellClass = embedMode
     ? 'relative mx-auto max-w-[1320px] px-3 py-3 sm:px-4 sm:py-4'
     : 'relative mx-auto max-w-[1440px] px-4 py-3 sm:px-6 sm:py-4';
+  const tabBoundaryResetKey = `${filters.tab}:${filters.sessionKey ?? 'none'}:${filters.lapNum}:${filters.driverNums.join(',')}`;
 
   useEffect(() => {
     if (typeof window === 'undefined') return;
@@ -452,14 +466,15 @@ export default function F1TelemetryDashboard() {
 
   const shareSnapshot = useCallback(async (snapshot: DashboardFilterSnapshot, label: string) => {
     const url = buildDashboardUrl(snapshot, splitMode, embedMode, themeMode);
+    let clipboardErrorMessage: string | null = null;
     try {
       if (navigator.clipboard?.writeText) {
         await navigator.clipboard.writeText(url);
         setFeedback(`${label} copied`);
         return;
       }
-    } catch {
-      // Fall back to navigator.share or prompt flow below.
+    } catch (error) {
+      clipboardErrorMessage = getClipboardErrorMessage(error, label);
     }
 
     try {
@@ -468,16 +483,19 @@ export default function F1TelemetryDashboard() {
         setFeedback(`${label} shared`);
         return;
       }
-    } catch {
-      // Ignore canceled shares and use the prompt fallback.
+    } catch (error) {
+      if (!isShareCancel(error)) {
+        clipboardErrorMessage = clipboardErrorMessage ?? `${label} could not be shared; copy manually`;
+      }
     }
 
     window.prompt('Copy this link', url);
-    setFeedback(`${label} ready`);
+    setFeedback(clipboardErrorMessage ?? `${label} ready`);
   }, [embedMode, splitMode, themeMode]);
 
   const embedSnapshot = useCallback(async (snapshot: DashboardFilterSnapshot, label: string) => {
     const snippet = buildIframeSnippet(snapshot, splitMode, themeMode);
+    let clipboardErrorMessage: string | null = null;
 
     try {
       if (navigator.clipboard?.writeText) {
@@ -485,12 +503,12 @@ export default function F1TelemetryDashboard() {
         setFeedback(`${label} copied`);
         return;
       }
-    } catch {
-      // Fall back to a prompt when clipboard access is unavailable.
+    } catch (error) {
+      clipboardErrorMessage = getClipboardErrorMessage(error, label);
     }
 
     window.prompt('Copy this iframe snippet', snippet);
-    setFeedback(`${label} ready`);
+    setFeedback(clipboardErrorMessage ?? `${label} ready`);
   }, [splitMode, themeMode]);
 
   const handleShare = useCallback(async () => {
@@ -511,6 +529,7 @@ export default function F1TelemetryDashboard() {
 
   const handleEmbedPanel = useCallback(async (panelId: string) => {
     const snippet = buildIframeSnippet(filters.snapshot, false, themeMode, panelId, 720);
+    let clipboardErrorMessage: string | null = null;
 
     try {
       if (navigator.clipboard?.writeText) {
@@ -518,12 +537,12 @@ export default function F1TelemetryDashboard() {
         setFeedback('Panel embed copied');
         return;
       }
-    } catch {
-      // Fall back to prompt when clipboard access is unavailable.
+    } catch (error) {
+      clipboardErrorMessage = getClipboardErrorMessage(error, 'Panel embed');
     }
 
     window.prompt('Copy this iframe snippet', snippet);
-    setFeedback('Panel embed ready');
+    setFeedback(clipboardErrorMessage ?? 'Panel embed ready');
   }, [filters.snapshot, themeMode]);
 
   const handlePrint = useCallback(() => {
@@ -610,9 +629,9 @@ export default function F1TelemetryDashboard() {
             onStepLap={stepLap}
           />
 
-          {meetings.error && <Err msg={`Failed to load calendar: ${meetings.error}`} />}
-          {sessions.error && <Err msg={`Failed to load sessions: ${sessions.error}`} />}
-          {drivers.error && <Err msg={`Failed to load drivers: ${drivers.error}`} />}
+          {meetings.error && <Err msg={`Failed to load calendar: ${meetings.error}`} onAction={meetings.refetch} />}
+          {sessions.error && <Err msg={`Failed to load sessions: ${sessions.error}`} onAction={sessions.refetch} />}
+          {drivers.error && <Err msg={`Failed to load drivers: ${drivers.error}`} onAction={drivers.refetch} />}
 
           {!embedMode && (
             <DriverSelector
@@ -631,6 +650,7 @@ export default function F1TelemetryDashboard() {
             onEmbedTab={handleEmbedTab}
           />
 
+          <ErrorBoundary label={TAB_LABELS[filters.tab]} resetKey={tabBoundaryResetKey}>
           <div className={contentLayoutClass}>
             {filters.tab === 'telemetry' && (
               <TelemetryTab
@@ -651,6 +671,7 @@ export default function F1TelemetryDashboard() {
                 driverColor={viewModel.driverColor}
                 embedMode={embedMode}
                 onEmbedPanel={handleEmbedPanel}
+                onTelemetryRetry={primaryTelemetry?.refetch}
               />
             )}
 
@@ -694,6 +715,7 @@ export default function F1TelemetryDashboard() {
                   error={teamRadio.error}
                   messages={viewModel.filteredRadio}
                   driverMap={selectionData.driverMap}
+                  onRetry={teamRadio.refetch}
                 />
               </Suspense>
             )}
@@ -704,6 +726,7 @@ export default function F1TelemetryDashboard() {
                   loading={raceControl.loading}
                   error={raceControl.error}
                   messages={viewModel.raceControlMessages}
+                  onRetry={raceControl.refetch}
                 />
               </Suspense>
             )}
@@ -719,6 +742,7 @@ export default function F1TelemetryDashboard() {
                   weatherTrend={viewModel.weatherTrend}
                   embedMode={embedMode}
                   onEmbedPanel={handleEmbedPanel}
+                  onRetry={weather.refetch}
                 />
               </Suspense>
             )}
@@ -779,6 +803,7 @@ export default function F1TelemetryDashboard() {
               </Suspense>
             )}
           </div>
+          </ErrorBoundary>
         </main>
       </div>
     </div>

--- a/src/components/dashboard/IncidentsTab.tsx
+++ b/src/components/dashboard/IncidentsTab.tsx
@@ -8,6 +8,7 @@ type Props = {
   loading: boolean;
   error: string | null;
   messages: OpenF1RaceControl[];
+  onRetry?: () => void;
 };
 
 function flagTone(flag: string) {
@@ -19,7 +20,7 @@ function flagTone(flag: string) {
   return 'bg-slate-500/15 text-slate-400';
 }
 
-export function IncidentsTab({ loading, error, messages }: Props) {
+export function IncidentsTab({ loading, error, messages, onRetry }: Props) {
   const [query, setQuery] = useState('');
   const [activeFilter, setActiveFilter] = useState('ALL');
 
@@ -39,7 +40,7 @@ export function IncidentsTab({ loading, error, messages }: Props) {
 
   return (
     <Panel title="Race Control" icon={<Flag size={14} className="text-yellow-500" />} sub="Official flags, penalties, safety car, and session status messages">
-      {loading ? <Spinner /> : error ? <Err msg={error} /> : messages.length > 0 ? (
+      {loading ? <Spinner /> : error ? <Err msg={error} onAction={onRetry} /> : messages.length > 0 ? (
         <>
           <div className="mb-4 flex flex-col gap-3 xl:flex-row xl:items-center xl:justify-between">
             <div className="relative min-w-0 flex-1 xl:max-w-sm">

--- a/src/components/dashboard/RadioTab.tsx
+++ b/src/components/dashboard/RadioTab.tsx
@@ -8,9 +8,10 @@ type Props = {
   error: string | null;
   messages: OpenF1TeamRadio[];
   driverMap: Record<number, OpenF1Driver>;
+  onRetry?: () => void;
 };
 
-export function RadioTab({ loading, error, messages, driverMap }: Props) {
+export function RadioTab({ loading, error, messages, driverMap, onRetry }: Props) {
   const radioMessages = useMemo(
     () => messages.map((message, index) => {
       const driver = driverMap[message.driver_number];
@@ -28,7 +29,7 @@ export function RadioTab({ loading, error, messages, driverMap }: Props) {
 
   return (
     <Panel title="Team Radio Recordings" icon={<Headphones size={14} style={{ color: 'var(--accent)' }} />} sub="Click to listen to actual team radio recordings from the session">
-      {loading ? <Spinner /> : error ? <Err msg={error} /> : radioMessages.length > 0 ? (
+      {loading ? <Spinner /> : error ? <Err msg={error} onAction={onRetry} /> : radioMessages.length > 0 ? (
         <div className="max-h-[500px] space-y-3 overflow-y-auto pr-2">
           {radioMessages.map((message) => (
             <div key={message.key} className="dashboard-card flex gap-3 rounded-[14px] p-3">

--- a/src/components/dashboard/TelemetryTab.tsx
+++ b/src/components/dashboard/TelemetryTab.tsx
@@ -3,7 +3,7 @@ import { Activity, Gauge, Timer, Trophy, Waves } from 'lucide-react';
 import { Area, CartesianGrid, ComposedChart, Line, LineChart, ReferenceLine, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
 import type { OpenF1Driver } from '../../api/openf1';
 import type { ComparisonPoint, DriverLapSummary, SectorRow, SpeedPoint } from './types';
-import { ChartTip, EmbedPanelButton, NoData, Panel, Spinner } from './shared';
+import { ChartTip, EmbedPanelButton, Err, NoData, Panel, Spinner } from './shared';
 import { ChartPanel, type ChartLegendItem } from './ChartPanel';
 import { fmtLap } from './utils';
 
@@ -25,6 +25,7 @@ type Props = {
   driverColor: (driverNumber: number) => string;
   embedMode?: boolean;
   onEmbedPanel?: (panelId: string) => void;
+  onTelemetryRetry?: () => void;
 };
 
 function getBestSector(rows: SectorRow[], key: 's1' | 's2' | 's3') {
@@ -52,6 +53,7 @@ export function TelemetryTab({
   driverColor,
   embedMode = false,
   onEmbedPanel,
+  onTelemetryRetry,
 }: Props) {
   const leader = lapSummaries[0];
   const bestS1 = getBestSector(sectorRows, 's1');
@@ -251,7 +253,7 @@ export function TelemetryTab({
         embedMode={embedMode}
         onEmbedPanel={onEmbedPanel}
       >
-        {telemetryLoading ? <Spinner label="Fetching car telemetry..." /> : telemetryError ? <NoData msg={telemetryError} /> : comparisonSpeedData.length > 0 ? (
+        {telemetryLoading ? <Spinner label="Fetching car telemetry..." /> : telemetryError ? <Err msg={telemetryError} onAction={onTelemetryRetry} /> : comparisonSpeedData.length > 0 ? (
           <div className="h-[200px] sm:h-[260px]">
             <ResponsiveContainer width="100%" height="100%">
               <LineChart data={comparisonSpeedData}>

--- a/src/components/dashboard/WeatherTab.tsx
+++ b/src/components/dashboard/WeatherTab.tsx
@@ -14,11 +14,12 @@ type Props = {
   weatherTrend: WeatherTrendPoint[];
   embedMode?: boolean;
   onEmbedPanel?: (panelId: string) => void;
+  onRetry?: () => void;
 };
 
-export function WeatherTab({ loading, error, latestWeather, sampleCount, weatherRadar, weatherTrend, embedMode = false, onEmbedPanel }: Props) {
+export function WeatherTab({ loading, error, latestWeather, sampleCount, weatherRadar, weatherTrend, embedMode = false, onEmbedPanel, onRetry }: Props) {
   if (loading) return <Spinner />;
-  if (error) return <Err msg={error} />;
+  if (error) return <Err msg={error} onAction={onRetry} />;
   if (!latestWeather) return <NoData msg="No weather data for this session." />;
   const chartGrid = 'var(--chart-grid)';
   const chartAxis = 'var(--chart-axis)';

--- a/src/components/dashboard/shared.tsx
+++ b/src/components/dashboard/shared.tsx
@@ -8,8 +8,22 @@ export function Spinner({ label }: { label?: string }) {
   return <div className="flex items-center justify-center gap-2 py-10 text-sm text-[color:var(--text-muted)]"><Loader2 size={16} className="animate-spin" />{label || 'Loading…'}</div>;
 }
 
-export function Err({ msg }: { msg: string }) {
-  return <div className="rounded-[20px] border border-red-500/10 bg-red-500/[0.04] py-10 text-center text-sm text-red-300/80"><AlertTriangle size={18} className="mx-auto mb-2 opacity-60" />{msg}</div>;
+export function Err({ msg, actionLabel = 'Try again', onAction }: { msg: string; actionLabel?: string; onAction?: () => void }) {
+  return (
+    <div className="rounded-[20px] border border-red-500/10 bg-red-500/[0.04] py-10 text-center text-sm text-red-300/80">
+      <AlertTriangle size={18} className="mx-auto mb-2 opacity-60" />
+      <p>{msg}</p>
+      {onAction && (
+        <button
+          type="button"
+          onClick={onAction}
+          className="mt-4 rounded-[10px] border border-red-400/20 bg-red-400/10 px-3 py-2 text-[10px] font-semibold uppercase tracking-[0.16em] text-red-200 transition-colors hover:bg-red-400/15"
+        >
+          {actionLabel}
+        </button>
+      )}
+    </div>
+  );
 }
 
 export function NoData({ msg }: { msg: string }) {

--- a/src/hooks/useDashboardFilters.ts
+++ b/src/hooks/useDashboardFilters.ts
@@ -10,25 +10,54 @@ export type DashboardFilterSnapshot = {
   tab: Tab;
 };
 
-function parsePositiveInt(value: string | null) {
+const VALID_YEAR_RANGE = [2023, new Date().getFullYear()] as const;
+const VALID_DRIVER_RANGE = [1, 99] as const;
+const VALID_LAP_RANGE = [1, 200] as const;
+const VALID_CIRCUIT_PATTERN = /^[A-Za-z0-9 ._'-]{1,80}$/;
+const VALID_TABS: Tab[] = ['telemetry', 'tires', 'energy', 'trackmap', 'positions', 'intervals', 'radio', 'incidents', 'weather', 'broadcast'];
+
+function parseBoundedInt(value: string | null, min: number, max: number) {
   if (!value) return null;
-  const parsed = Number(value);
-  return Number.isInteger(parsed) && parsed > 0 ? parsed : null;
+  const trimmed = value.trim();
+  if (!/^\d+$/.test(trimmed)) return null;
+  const parsed = Number(trimmed);
+  return Number.isSafeInteger(parsed) && parsed >= min && parsed <= max ? parsed : null;
+}
+
+function parseYear(value: string | null) {
+  return parseBoundedInt(value, VALID_YEAR_RANGE[0], VALID_YEAR_RANGE[1]);
+}
+
+function parseDriverNumber(value: string | null) {
+  return parseBoundedInt(value, VALID_DRIVER_RANGE[0], VALID_DRIVER_RANGE[1]);
+}
+
+function parseSessionKey(value: string | null) {
+  return parseBoundedInt(value, 1, Number.MAX_SAFE_INTEGER);
+}
+
+function parseLapNumber(value: string | null) {
+  return parseBoundedInt(value, VALID_LAP_RANGE[0], VALID_LAP_RANGE[1]);
+}
+
+function parseCircuit(value: string | null) {
+  const trimmed = value?.trim();
+  if (!trimmed) return null;
+  return VALID_CIRCUIT_PATTERN.test(trimmed) ? trimmed : null;
 }
 
 function parseDriverNumbers(value: string | null) {
   if (!value) return [];
   return value
     .split(',')
-    .map((part) => parsePositiveInt(part))
+    .map((part) => parseDriverNumber(part))
     .filter((part): part is number => part != null)
     .filter((part, index, all) => all.indexOf(part) === index)
     .slice(0, 4);
 }
 
 function parseTab(value: string | null): Tab | null {
-  const tabs: Tab[] = ['telemetry', 'tires', 'energy', 'trackmap', 'positions', 'intervals', 'radio', 'incidents', 'weather'];
-  return value && tabs.includes(value as Tab) ? value as Tab : null;
+  return value && VALID_TABS.includes(value as Tab) ? value as Tab : null;
 }
 
 function readInitialSnapshot(): Partial<DashboardFilterSnapshot> {
@@ -36,11 +65,11 @@ function readInitialSnapshot(): Partial<DashboardFilterSnapshot> {
 
   const params = new URLSearchParams(window.location.search);
   return {
-    year: parsePositiveInt(params.get('year')) ?? undefined,
-    circuit: params.get('circuit') || null,
-    sessionKey: parsePositiveInt(params.get('session')),
+    year: parseYear(params.get('year')) ?? undefined,
+    circuit: parseCircuit(params.get('circuit')),
+    sessionKey: parseSessionKey(params.get('session')),
     driverNums: parseDriverNumbers(params.get('drivers')),
-    lapNum: parsePositiveInt(params.get('lap')) ?? undefined,
+    lapNum: parseLapNumber(params.get('lap')) ?? undefined,
     tab: parseTab(params.get('tab')) ?? undefined,
   };
 }

--- a/src/hooks/useDashboardSelectionData.ts
+++ b/src/hooks/useDashboardSelectionData.ts
@@ -1,6 +1,6 @@
-import { useEffect, useMemo } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import type { OpenF1Driver, OpenF1Lap, OpenF1Meeting, OpenF1Session, OpenF1SessionResult } from '../api/openf1';
-import type { FetchState } from './useOpenF1';
+import { invalidateOpenF1SessionCache, type FetchState } from './useOpenF1';
 import type { SelectOption } from '../components/dashboard/types';
 
 type Params = {
@@ -62,6 +62,16 @@ export function useDashboardSelectionData({
   setDriverNums,
   setLapNum,
 }: Params) {
+  const previousSessionKeyRef = useRef<number | null>(sessionKey);
+
+  useEffect(() => {
+    const previousSessionKey = previousSessionKeyRef.current;
+    if (previousSessionKey != null && previousSessionKey !== sessionKey) {
+      invalidateOpenF1SessionCache(previousSessionKey);
+    }
+    previousSessionKeyRef.current = sessionKey;
+  }, [sessionKey]);
+
   const circuitOptions = useMemo<SelectOption<string>[]>(() => {
     if (!meetings?.length) return [];
     const seen = new Set<string>();

--- a/src/hooks/useOpenF1.ts
+++ b/src/hooks/useOpenF1.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useCallback, useEffect, useRef } from 'react';
 import type {
   OpenF1Meeting, OpenF1Session, OpenF1Driver, OpenF1Lap,
   OpenF1CarData, OpenF1Stint, OpenF1Pit, OpenF1Weather,
@@ -62,13 +62,50 @@ function clearExpiredCacheEntries() {
   }
 }
 
+function isSessionScopedCacheKey(key: string, sessionKey: number) {
+  return (
+    key === `drivers:${sessionKey}`
+    || key === `stints:${sessionKey}`
+    || key === `pits:${sessionKey}`
+    || key === `weather:${sessionKey}`
+    || key === `rc:${sessionKey}`
+    || key === `radio:${sessionKey}`
+    || key === `result:${sessionKey}`
+    || key === `positions:${sessionKey}`
+    || key === `intervals:${sessionKey}`
+    || key.startsWith(`laps:${sessionKey}:`)
+    || key.startsWith(`telem:${sessionKey}:`)
+    || key.startsWith(`location:${sessionKey}:`)
+  );
+}
+
+export function invalidateOpenF1SessionCache(sessionKey: number | null | undefined) {
+  if (sessionKey == null) return;
+
+  for (const key of cache.keys()) {
+    if (isSessionScopedCacheKey(key, sessionKey)) {
+      cache.delete(key);
+    }
+  }
+
+  for (const [key, entry] of inflight.entries()) {
+    if (isSessionScopedCacheKey(key, sessionKey)) {
+      entry.controller.abort();
+      inflight.delete(key);
+    }
+  }
+}
+
 // ─── Generic hook ────────────────────────────────────────────────────────────
 
 export interface FetchState<T> {
   data: T | null;
   loading: boolean;
   error: string | null;
+  refetch: () => void;
 }
+
+type FetchDataState<T> = Omit<FetchState<T>, 'refetch'>;
 
 /**
  * Core data-fetching hook.
@@ -79,12 +116,25 @@ export interface FetchState<T> {
  * so the closure always captures the latest params.
  */
 function useFetch<T>(key: string | null, fetcher: (signal: AbortSignal) => Promise<T>): FetchState<T> {
-  const [state, setState] = useState<FetchState<T>>({ data: null, loading: false, error: null });
+  const [state, setState] = useState<FetchDataState<T>>({ data: null, loading: false, error: null });
+  const [refetchToken, setRefetchToken] = useState(0);
   const fetcherRef = useRef(fetcher);
   const seqRef = useRef(0);
 
   // Always keep fetcherRef current
   fetcherRef.current = fetcher;
+
+  const refetch = useCallback(() => {
+    if (!key) return;
+
+    cache.delete(key);
+    const active = inflight.get(key);
+    if (active) {
+      active.controller.abort();
+      inflight.delete(key);
+    }
+    setRefetchToken((token) => token + 1);
+  }, [key]);
 
   useEffect(() => {
     if (!key) {
@@ -151,9 +201,9 @@ function useFetch<T>(key: string | null, fetcher: (signal: AbortSignal) => Promi
         inflight.delete(key);
       }
     };
-  }, [key]); // ONLY key — fetcher is accessed via ref
+  }, [key, refetchToken]); // key/refetchToken drive fetches — fetcher is accessed via ref
 
-  return state;
+  return { ...state, refetch };
 }
 
 // ─── Typed hooks ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- add a tab-level ErrorBoundary with retry/reset handling
- expose refetch from OpenF1 fetch hooks and wire retry actions into displayed API errors
- validate URL filter params and invalidate stale session-scoped cache entries on session changes
- surface clipboard/share failures with actionable feedback

## Verification
- npm run typecheck
- npm run lint
- npm run build