### PR TITLE
refactor: extract constants, remove dead code, add JSDoc, uniform patterns

### DIFF
--- a/src/api/openf1.ts
+++ b/src/api/openf1.ts
@@ -9,6 +9,7 @@
 const BASE = 'https://api.openf1.org/v1';
 const DEFAULT_TIMEOUT_MS = 12_000;
 const DEFAULT_RETRIES = 2;
+const FALLBACK_LAP_WINDOW_MS = 120_000;
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -152,9 +153,6 @@ export interface OpenF1SessionResult {
 }
 
 // ─── URL builder ─────────────────────────────────────────────────────────────
-// OpenF1 requires literal operators in param names: date>=VALUE, speed<=VALUE
-// We must NOT percent-encode the keys, but we DO encode values (except dates
-// where the API accepts ISO strings with colons).
 
 type QueryValue = string | number | boolean | null | undefined;
 type RequestOptions = {
@@ -167,6 +165,11 @@ function sortEntries(params: Record<string, QueryValue>) {
   return Object.entries(params).sort(([left], [right]) => left.localeCompare(right));
 }
 
+/**
+ * Builds OpenF1 query URLs while preserving operator syntax in parameter names.
+ * Supported keys include plain filters (`session_key`) and OpenF1 operator keys
+ * such as `date>=`, `date<=`, `speed>=`; keys are not encoded, values are.
+ */
 function buildUrl(endpoint: string, params: Record<string, QueryValue>): string {
   const parts = sortEntries(params)
     .filter(([, v]) => v !== undefined && v !== null && v !== '')
@@ -174,7 +177,11 @@ function buildUrl(endpoint: string, params: Record<string, QueryValue>): string 
   return `${BASE}/${endpoint}${parts.length ? '?' + parts.join('&') : ''}`;
 }
 
-// For date range filters: key already includes the operator, value is an ISO date
+/**
+ * Builds URLs for date-windowed endpoints. `dateFilters` keys must include the
+ * OpenF1 operator (`date>=`, `date<=`) and values are appended as ISO strings
+ * without escaping colons, matching the API's expected filter format.
+ */
 function buildUrlWithDateFilters(
   endpoint: string,
   params: Record<string, QueryValue>,
@@ -185,9 +192,8 @@ function buildUrlWithDateFilters(
     if (v === undefined || v === null || v === '') continue;
     parts.push(`${k}=${encodeURIComponent(String(v))}`);
   }
-  // Date filters: key is like "date>=" and value is ISO — don't encode colons in dates
   for (const [k, v] of sortEntries(dateFilters)) {
-    parts.push(`${k}${v}`);  // e.g. "date>=2024-03-01T12:00:00.000+00:00"
+    parts.push(`${k}${v}`);
   }
   return `${BASE}/${endpoint}?${parts.join('&')}`;
 }
@@ -374,7 +380,7 @@ export function getLocationForLap(
   options?: RequestOptions,
 ): Promise<OpenF1Location[]> {
   const dateEnd = nextLapDateStart
-    || new Date(new Date(lapDateStart).getTime() + 120_000).toISOString();
+    || new Date(new Date(lapDateStart).getTime() + FALLBACK_LAP_WINDOW_MS).toISOString();
   const url = buildUrlWithDateFilters(
     'location',
     { session_key: sessionKey, driver_number: driverNumber },
@@ -393,7 +399,7 @@ export function getCarDataForLap(
   options?: RequestOptions,
 ): Promise<OpenF1CarData[]> {
   const dateEnd = nextLapDateStart
-    || new Date(new Date(lapDateStart).getTime() + 120_000).toISOString();
+    || new Date(new Date(lapDateStart).getTime() + FALLBACK_LAP_WINDOW_MS).toISOString();
 
   const url = buildUrlWithDateFilters(
     'car_data',

--- a/src/components/F1TelemetryDashboard.tsx
+++ b/src/components/F1TelemetryDashboard.tsx
@@ -4,6 +4,7 @@ import type { DashboardFilterSnapshot } from '../hooks/useDashboardFilters';
 import { useDashboardSelectionData } from '../hooks/useDashboardSelectionData';
 import { useDashboardViewModel } from '../hooks/useDashboardViewModel';
 import { COLORS } from '../constants/colors';
+import { DriverProvider } from '../contexts/DriverContext';
 import {
   useDrivers,
   useIntervals,
@@ -43,6 +44,11 @@ type SavedPreset = {
 const PRESET_STORAGE_KEY = 'f1-telemetry-dashboard:presets';
 const THEME_STORAGE_KEY = 'f1-telemetry-dashboard:theme';
 const MAX_DRIVER_SLOTS = 4;
+const HASH_SCROLL_MAX_ATTEMPTS = 12;
+const HASH_SCROLL_INTERVAL_MS = 120;
+const FEEDBACK_CLEAR_MS = 2600;
+const DEFAULT_IFRAME_HEIGHT = 920;
+const PANEL_IFRAME_HEIGHT = 720;
 const YEAR_OPTIONS = Array.from(
   { length: new Date().getFullYear() - 2022 },
   (_, index) => 2023 + index,
@@ -121,6 +127,11 @@ function readSavedPresets() {
   }
 }
 
+/**
+ * Builds shareable dashboard URLs from the persisted filter schema.
+ * Query params are: year, circuit, session, drivers, lap, tab, optional layout,
+ * optional embed=1, optional theme=light, and an optional panel hash anchor.
+ */
 function buildDashboardUrl(
   snapshot: DashboardFilterSnapshot,
   splitMode: boolean,
@@ -151,7 +162,7 @@ function buildIframeSnippet(
   splitMode: boolean,
   themeMode: ThemeMode,
   anchorId?: string,
-  iframeHeight = 920,
+  iframeHeight = DEFAULT_IFRAME_HEIGHT,
 ) {
   const src = buildDashboardUrl(snapshot, splitMode, true, themeMode, anchorId);
   const background = themeMode === 'light' ? COLORS.fallback.iframeLight : COLORS.fallback.iframeDark;
@@ -177,6 +188,47 @@ function getClipboardErrorMessage(error: unknown, label: string) {
 
 function isShareCancel(error: unknown) {
   return typeof DOMException !== 'undefined' && error instanceof DOMException && error.name === 'AbortError';
+}
+
+function useDriverLapData(sessionKey: number | null, driverNumber: number | null) {
+  return useLaps(sessionKey, driverNumber);
+}
+
+type DriverTelemetryWindow = {
+  lapStart: string | null;
+  nextLapStart: string | null;
+};
+
+function useDriverWindowData({
+  sessionKey,
+  driverNumber,
+  telemetryWindow,
+  needsTelemetryData,
+  needsLocationData,
+}: {
+  sessionKey: number | null;
+  driverNumber: number | null;
+  telemetryWindow?: DriverTelemetryWindow;
+  needsTelemetryData: boolean;
+  needsLocationData: boolean;
+}) {
+  const lapStart = telemetryWindow?.lapStart || null;
+  const nextLapStart = telemetryWindow?.nextLapStart || null;
+
+  const telemetry = useLapTelemetry(
+    sessionKey,
+    driverNumber,
+    needsTelemetryData ? lapStart : null,
+    needsTelemetryData ? nextLapStart : null,
+  );
+  const location = useLapLocation(
+    needsLocationData ? sessionKey : null,
+    driverNumber,
+    needsLocationData ? lapStart : null,
+    needsLocationData ? nextLapStart : null,
+  );
+
+  return { telemetry, location };
 }
 
 export default function F1TelemetryDashboard() {
@@ -207,10 +259,10 @@ export default function F1TelemetryDashboard() {
   );
 
   const lapStates = [
-    useLaps(filters.sessionKey, driverSlots[0]),
-    useLaps(filters.sessionKey, driverSlots[1]),
-    useLaps(filters.sessionKey, driverSlots[2]),
-    useLaps(filters.sessionKey, driverSlots[3]),
+    useDriverLapData(filters.sessionKey, driverSlots[0]),
+    useDriverLapData(filters.sessionKey, driverSlots[1]),
+    useDriverLapData(filters.sessionKey, driverSlots[2]),
+    useDriverLapData(filters.sessionKey, driverSlots[3]),
   ];
 
   const stints = useStints(needsStrategyData ? filters.sessionKey : null);
@@ -240,44 +292,52 @@ export default function F1TelemetryDashboard() {
     setLapNum: filters.setAutoLapNum,
   });
 
+  const driver0Data = useDriverWindowData({
+    sessionKey: filters.sessionKey,
+    driverNumber: driverSlots[0],
+    telemetryWindow: selectionData.telemetryWindows[0],
+    needsTelemetryData,
+    needsLocationData,
+  });
+  const driver1Data = useDriverWindowData({
+    sessionKey: filters.sessionKey,
+    driverNumber: driverSlots[1],
+    telemetryWindow: selectionData.telemetryWindows[1],
+    needsTelemetryData,
+    needsLocationData,
+  });
+  const driver2Data = useDriverWindowData({
+    sessionKey: filters.sessionKey,
+    driverNumber: driverSlots[2],
+    telemetryWindow: selectionData.telemetryWindows[2],
+    needsTelemetryData,
+    needsLocationData,
+  });
+  const driver3Data = useDriverWindowData({
+    sessionKey: filters.sessionKey,
+    driverNumber: driverSlots[3],
+    telemetryWindow: selectionData.telemetryWindows[3],
+    needsTelemetryData,
+    needsLocationData,
+  });
+
   const telemetryStates = [
-    useLapTelemetry(
-      filters.sessionKey,
-      driverSlots[0],
-      needsTelemetryData ? selectionData.telemetryWindows[0]?.lapStart || null : null,
-      needsTelemetryData ? selectionData.telemetryWindows[0]?.nextLapStart || null : null,
-    ),
-    useLapTelemetry(
-      filters.sessionKey,
-      driverSlots[1],
-      needsTelemetryData ? selectionData.telemetryWindows[1]?.lapStart || null : null,
-      needsTelemetryData ? selectionData.telemetryWindows[1]?.nextLapStart || null : null,
-    ),
-    useLapTelemetry(
-      filters.sessionKey,
-      driverSlots[2],
-      needsTelemetryData ? selectionData.telemetryWindows[2]?.lapStart || null : null,
-      needsTelemetryData ? selectionData.telemetryWindows[2]?.nextLapStart || null : null,
-    ),
-    useLapTelemetry(
-      filters.sessionKey,
-      driverSlots[3],
-      needsTelemetryData ? selectionData.telemetryWindows[3]?.lapStart || null : null,
-      needsTelemetryData ? selectionData.telemetryWindows[3]?.nextLapStart || null : null,
-    ),
+    driver0Data.telemetry,
+    driver1Data.telemetry,
+    driver2Data.telemetry,
+    driver3Data.telemetry,
   ];
 
   const locationStates = [
-    useLapLocation(needsLocationData ? filters.sessionKey : null, driverSlots[0], needsLocationData ? selectionData.telemetryWindows[0]?.lapStart || null : null, needsLocationData ? selectionData.telemetryWindows[0]?.nextLapStart || null : null),
-    useLapLocation(needsLocationData ? filters.sessionKey : null, driverSlots[1], needsLocationData ? selectionData.telemetryWindows[1]?.lapStart || null : null, needsLocationData ? selectionData.telemetryWindows[1]?.nextLapStart || null : null),
-    useLapLocation(needsLocationData ? filters.sessionKey : null, driverSlots[2], needsLocationData ? selectionData.telemetryWindows[2]?.lapStart || null : null, needsLocationData ? selectionData.telemetryWindows[2]?.nextLapStart || null : null),
-    useLapLocation(needsLocationData ? filters.sessionKey : null, driverSlots[3], needsLocationData ? selectionData.telemetryWindows[3]?.lapStart || null : null, needsLocationData ? selectionData.telemetryWindows[3]?.nextLapStart || null : null),
+    driver0Data.location,
+    driver1Data.location,
+    driver2Data.location,
+    driver3Data.location,
   ];
   const locationByDriver = Object.fromEntries(
     filters.driverNums.map((driverNum, index) => [driverNum, locationStates[index]?.data || null]),
   ) as Record<number, ReturnType<typeof useLapLocation>['data']>;
   const locationLoading = needsLocationData && locationStates.some((s) => s.loading);
-  const primaryTelemetry = telemetryStates[0];
   const telemetryByDriver = Object.fromEntries(
     filters.driverNums.map((driverNumber, index) => [driverNumber, telemetryStates[index]?.data || null]),
   ) as Record<number, ReturnType<typeof useLapTelemetry>['data']>;
@@ -296,6 +356,14 @@ export default function F1TelemetryDashboard() {
     teamRadio: teamRadio.data,
     telemetryByDriver,
   });
+  const driverContextValue = useMemo(
+    () => ({
+      driverNums: filters.driverNums,
+      driverMap: selectionData.driverMap,
+      driverColor: viewModel.driverColor,
+    }),
+    [filters.driverNums, selectionData.driverMap, viewModel.driverColor],
+  );
 
   const anyLoading = meetings.loading || sessions.loading || drivers.loading || sessionResults.loading;
   const lapsLoading = lapStates.some((state) => state.loading);
@@ -396,10 +464,10 @@ export default function F1TelemetryDashboard() {
       }
 
       attempts += 1;
-      if (attempts >= 12) {
+      if (attempts >= HASH_SCROLL_MAX_ATTEMPTS) {
         window.clearInterval(timerId);
       }
-    }, 120);
+    }, HASH_SCROLL_INTERVAL_MS);
 
     return () => window.clearInterval(timerId);
   }, [filters.tab]);
@@ -416,7 +484,7 @@ export default function F1TelemetryDashboard() {
   useEffect(() => {
     if (!feedback || typeof window === 'undefined') return;
 
-    const timeoutId = window.setTimeout(() => setFeedback(null), 2600);
+    const timeoutId = window.setTimeout(() => setFeedback(null), FEEDBACK_CLEAR_MS);
     return () => window.clearTimeout(timeoutId);
   }, [feedback]);
 
@@ -529,7 +597,7 @@ export default function F1TelemetryDashboard() {
   }, [embedSnapshot, filters.snapshot]);
 
   const handleEmbedPanel = useCallback(async (panelId: string) => {
-    const snippet = buildIframeSnippet(filters.snapshot, false, themeMode, panelId, 720);
+    const snippet = buildIframeSnippet(filters.snapshot, false, themeMode, panelId, PANEL_IFRAME_HEIGHT);
     let clipboardErrorMessage: string | null = null;
 
     try {
@@ -651,160 +719,143 @@ export default function F1TelemetryDashboard() {
             onEmbedTab={handleEmbedTab}
           />
 
-          <ErrorBoundary label={TAB_LABELS[filters.tab]} resetKey={tabBoundaryResetKey}>
-          <div className={contentLayoutClass}>
-            {filters.tab === 'telemetry' && (
-              <TelemetryTab
-                lapNum={filters.lapNum}
-                lapsLoading={lapsLoading}
-                sectorRows={viewModel.sectorRows}
-                telemetryLoading={telemetryLoading}
-                telemetryError={primaryTelemetry?.error || null}
-                telemetryPoints={primaryTelemetry?.data?.length || 0}
-                speedData={viewModel.speedData}
-                comparisonSpeedData={viewModel.comparisonSpeedData}
-                comparisonControlData={viewModel.comparisonControlData}
-                lapTimeData={viewModel.lapTimeData}
-                lapDeltaData={viewModel.lapDeltaData}
-                lapSummaries={viewModel.lapSummaries}
-                driverNums={filters.driverNums}
-                driverMap={selectionData.driverMap}
-                driverColor={viewModel.driverColor}
-                embedMode={embedMode}
-                onEmbedPanel={handleEmbedPanel}
-                onTelemetryRetry={primaryTelemetry?.refetch}
-              />
-            )}
+          <DriverProvider {...driverContextValue}>
+            <ErrorBoundary label={TAB_LABELS[filters.tab]} resetKey={tabBoundaryResetKey}>
+              <div className={contentLayoutClass}>
+                {filters.tab === 'telemetry' && (
+                  <TelemetryTab
+                    lapNum={filters.lapNum}
+                    lapsLoading={lapsLoading}
+                    sectorRows={viewModel.sectorRows}
+                    telemetryLoading={telemetryLoading}
+                    telemetryError={telemetryStates[0].error}
+                    telemetryPoints={telemetryStates[0].data?.length || 0}
+                    speedData={viewModel.speedData}
+                    comparisonSpeedData={viewModel.comparisonSpeedData}
+                    comparisonControlData={viewModel.comparisonControlData}
+                    lapTimeData={viewModel.lapTimeData}
+                    lapDeltaData={viewModel.lapDeltaData}
+                    lapSummaries={viewModel.lapSummaries}
+                    embedMode={embedMode}
+                    onEmbedPanel={handleEmbedPanel}
+                    onTelemetryRetry={telemetryStates[0].refetch}
+                  />
+                )}
 
-            {filters.tab === 'tires' && (
-              <Suspense fallback={<TabLoadingPlaceholder label="Loading strategy view..." />}>
-                <StrategyTab
-                  lapNum={filters.lapNum}
-                  driverNums={filters.driverNums}
-                  driverMap={selectionData.driverMap}
-                  stintsLoading={stints.loading}
-                  stintsByDriver={viewModel.stintsByDriver}
-                  pitsLoading={pits.loading}
-                  filteredPits={viewModel.filteredPits}
-                  embedMode={embedMode}
-                  onEmbedPanel={handleEmbedPanel}
-                />
-              </Suspense>
-            )}
+                {filters.tab === 'tires' && (
+                  <Suspense fallback={<TabLoadingPlaceholder label="Loading strategy view..." />}>
+                    <StrategyTab
+                      lapNum={filters.lapNum}
+                      stintsLoading={stints.loading}
+                      stintsByDriver={viewModel.stintsByDriver}
+                      pitsLoading={pits.loading}
+                      filteredPits={viewModel.filteredPits}
+                      embedMode={embedMode}
+                      onEmbedPanel={handleEmbedPanel}
+                    />
+                  </Suspense>
+                )}
 
-            {filters.tab === 'energy' && (
-              <Suspense fallback={<TabLoadingPlaceholder label="Loading energy view..." />}>
-                <EnergyTab
-                  lapNum={filters.lapNum}
-                  driverNums={filters.driverNums}
-                  driverMap={selectionData.driverMap}
-                  speedData={viewModel.speedData}
-                  comparisonEnergyData={viewModel.comparisonEnergyData}
-                  lapSummaries={viewModel.lapSummaries}
-                  driverColor={viewModel.driverColor}
-                  telemetryLoading={telemetryLoading}
-                  embedMode={embedMode}
-                  onEmbedPanel={handleEmbedPanel}
-                />
-              </Suspense>
-            )}
+                {filters.tab === 'energy' && (
+                  <Suspense fallback={<TabLoadingPlaceholder label="Loading energy view..." />}>
+                    <EnergyTab
+                      lapNum={filters.lapNum}
+                      speedData={viewModel.speedData}
+                      comparisonEnergyData={viewModel.comparisonEnergyData}
+                      lapSummaries={viewModel.lapSummaries}
+                      telemetryLoading={telemetryLoading}
+                      embedMode={embedMode}
+                      onEmbedPanel={handleEmbedPanel}
+                    />
+                  </Suspense>
+                )}
 
-            {filters.tab === 'radio' && (
-              <Suspense fallback={<TabLoadingPlaceholder label="Loading radio view..." />}>
-                <RadioTab
-                  loading={teamRadio.loading}
-                  error={teamRadio.error}
-                  messages={viewModel.filteredRadio}
-                  driverMap={selectionData.driverMap}
-                  onRetry={teamRadio.refetch}
-                />
-              </Suspense>
-            )}
+                {filters.tab === 'radio' && (
+                  <Suspense fallback={<TabLoadingPlaceholder label="Loading radio view..." />}>
+                    <RadioTab
+                      loading={teamRadio.loading}
+                      error={teamRadio.error}
+                      messages={viewModel.filteredRadio}
+                      onRetry={teamRadio.refetch}
+                    />
+                  </Suspense>
+                )}
 
-            {filters.tab === 'incidents' && (
-              <Suspense fallback={<TabLoadingPlaceholder label="Loading race control view..." />}>
-                <IncidentsTab
-                  loading={raceControl.loading}
-                  error={raceControl.error}
-                  messages={viewModel.raceControlMessages}
-                  onRetry={raceControl.refetch}
-                />
-              </Suspense>
-            )}
+                {filters.tab === 'incidents' && (
+                  <Suspense fallback={<TabLoadingPlaceholder label="Loading race control view..." />}>
+                    <IncidentsTab
+                      loading={raceControl.loading}
+                      error={raceControl.error}
+                      messages={viewModel.raceControlMessages}
+                      onRetry={raceControl.refetch}
+                    />
+                  </Suspense>
+                )}
 
-            {filters.tab === 'weather' && (
-              <Suspense fallback={<TabLoadingPlaceholder label="Loading weather view..." />}>
-                <WeatherTab
-                  loading={weather.loading}
-                  error={weather.error}
-                  latestWeather={viewModel.latestWeather}
-                  sampleCount={weather.data?.length || 0}
-                  weatherRadar={viewModel.weatherRadar}
-                  weatherTrend={viewModel.weatherTrend}
-                  embedMode={embedMode}
-                  onEmbedPanel={handleEmbedPanel}
-                  onRetry={weather.refetch}
-                />
-              </Suspense>
-            )}
+                {filters.tab === 'weather' && (
+                  <Suspense fallback={<TabLoadingPlaceholder label="Loading weather view..." />}>
+                    <WeatherTab
+                      loading={weather.loading}
+                      error={weather.error}
+                      latestWeather={viewModel.latestWeather}
+                      sampleCount={weather.data?.length || 0}
+                      weatherRadar={viewModel.weatherRadar}
+                      weatherTrend={viewModel.weatherTrend}
+                      embedMode={embedMode}
+                      onEmbedPanel={handleEmbedPanel}
+                      onRetry={weather.refetch}
+                    />
+                  </Suspense>
+                )}
 
-            {filters.tab === 'trackmap' && (
-              <TrackMapTab
-                lapNum={filters.lapNum}
-                driverNums={filters.driverNums}
-                driverMap={selectionData.driverMap}
-                locationByDriver={locationByDriver}
-                locationLoading={locationLoading}
-                driverColor={viewModel.driverColor}
-                embedMode={embedMode}
-                onEmbedPanel={handleEmbedPanel}
-              />
-            )}
+                {filters.tab === 'trackmap' && (
+                  <TrackMapTab
+                    lapNum={filters.lapNum}
+                    locationByDriver={locationByDriver}
+                    locationLoading={locationLoading}
+                    embedMode={embedMode}
+                    onEmbedPanel={handleEmbedPanel}
+                  />
+                )}
 
-            {filters.tab === 'positions' && (
-              <Suspense fallback={<TabLoadingPlaceholder label="Loading race positions..." />}>
-                <PositionsTab
-                  driverNums={filters.driverNums}
-                  driverMap={selectionData.driverMap}
-                  positions={positions.data}
-                  positionsLoading={positions.loading}
-                  lapNum={filters.lapNum}
-                  driverColor={viewModel.driverColor}
-                  embedMode={embedMode}
-                  onEmbedPanel={handleEmbedPanel}
-                />
-              </Suspense>
-            )}
+                {filters.tab === 'positions' && (
+                  <Suspense fallback={<TabLoadingPlaceholder label="Loading race positions..." />}>
+                    <PositionsTab
+                      positions={positions.data}
+                      positionsLoading={positions.loading}
+                      lapNum={filters.lapNum}
+                      embedMode={embedMode}
+                      onEmbedPanel={handleEmbedPanel}
+                    />
+                  </Suspense>
+                )}
 
-            {filters.tab === 'intervals' && (
-              <Suspense fallback={<TabLoadingPlaceholder label="Loading interval data..." />}>
-                <IntervalsTab
-                  driverNums={filters.driverNums}
-                  driverMap={selectionData.driverMap}
-                  intervals={intervals.data}
-                  intervalsLoading={intervals.loading}
-                  driverColor={viewModel.driverColor}
-                  embedMode={embedMode}
-                  onEmbedPanel={handleEmbedPanel}
-                />
-              </Suspense>
-            )}
+                {filters.tab === 'intervals' && (
+                  <Suspense fallback={<TabLoadingPlaceholder label="Loading interval data..." />}>
+                    <IntervalsTab
+                      intervals={intervals.data}
+                      intervalsLoading={intervals.loading}
+                      embedMode={embedMode}
+                      onEmbedPanel={handleEmbedPanel}
+                    />
+                  </Suspense>
+                )}
 
-            {filters.tab === 'broadcast' && (
-              <Suspense fallback={<TabLoadingPlaceholder label="Loading broadcast view..." />}>
-                <BroadcastTab
-                  lapNum={filters.lapNum}
-                  lapsLoading={lapsLoading}
-                  sectorRows={viewModel.sectorRows}
-                  lapSummaries={viewModel.lapSummaries}
-                  driverMap={selectionData.driverMap}
-                  embedMode={embedMode}
-                  onEmbedPanel={handleEmbedPanel}
-                />
-              </Suspense>
-            )}
-          </div>
-          </ErrorBoundary>
+                {filters.tab === 'broadcast' && (
+                  <Suspense fallback={<TabLoadingPlaceholder label="Loading broadcast view..." />}>
+                    <BroadcastTab
+                      lapNum={filters.lapNum}
+                      lapsLoading={lapsLoading}
+                      sectorRows={viewModel.sectorRows}
+                      lapSummaries={viewModel.lapSummaries}
+                      embedMode={embedMode}
+                      onEmbedPanel={handleEmbedPanel}
+                    />
+                  </Suspense>
+                )}
+              </div>
+            </ErrorBoundary>
+          </DriverProvider>
         </main>
       </div>
     </div>

--- a/src/components/dashboard/BroadcastTab.tsx
+++ b/src/components/dashboard/BroadcastTab.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from 'react';
 import { Gauge, LayoutGrid, Timer, Tv2 } from 'lucide-react';
-import type { OpenF1Driver } from '../../api/openf1';
 import { COLORS } from '../../constants/colors';
+import { useDriverContext } from '../../contexts/useDriverContext';
 import type { DriverLapSummary, SectorRow } from './types';
 import { EmbedPanelButton, NoData, Panel, TableSkeleton } from './shared';
 import { fmtLap } from './utils';
@@ -113,7 +113,6 @@ type Props = {
   lapsLoading: boolean;
   sectorRows: SectorRow[];
   lapSummaries: DriverLapSummary[];
-  driverMap: Record<number, OpenF1Driver>;
   embedMode?: boolean;
   onEmbedPanel?: (panelId: string) => void;
 };
@@ -125,10 +124,10 @@ export function BroadcastTab({
   lapsLoading,
   sectorRows,
   lapSummaries,
-  driverMap,
   embedMode = false,
   onEmbedPanel,
 }: Props) {
+  const { driverMap } = useDriverContext();
   // Sort by lap time for timing tower ordering
   const sorted = useMemo(
     () =>

--- a/src/components/dashboard/ChartPanel.tsx
+++ b/src/components/dashboard/ChartPanel.tsx
@@ -1,15 +1,11 @@
 import { useEffect, useRef, useState, type ReactNode } from 'react';
 import { Download, Expand, Shrink } from 'lucide-react';
 import { COLORS } from '../../constants/colors';
+import { exportChartAsSvg, sanitizeFilename, type ExportChartLegendItem } from '../../utils/exportChart';
 import { EmbedPanelButton, Panel, ToolbarButton } from './shared';
 import { cn } from './utils';
 
-export type ChartLegendItem = {
-  label: string;
-  color: string;
-  variant?: 'line' | 'area' | 'bar';
-  dashed?: boolean;
-};
+export type ChartLegendItem = ExportChartLegendItem;
 
 type Props = {
   title: string;
@@ -24,133 +20,6 @@ type Props = {
   embedMode?: boolean;
   onEmbedPanel?: (panelId: string) => void;
 };
-
-function getChartDimensions(svg: SVGSVGElement, fallbackWidth: number, fallbackHeight: number) {
-  const widthAttr = Number(svg.getAttribute('width'));
-  const heightAttr = Number(svg.getAttribute('height'));
-  const viewBox = svg.viewBox.baseVal;
-
-  return {
-    width: Number.isFinite(widthAttr) && widthAttr > 0 ? widthAttr : (viewBox?.width || fallbackWidth || 1200),
-    height: Number.isFinite(heightAttr) && heightAttr > 0 ? heightAttr : (viewBox?.height || fallbackHeight || 480),
-  };
-}
-
-function appendLegend(
-  root: SVGSVGElement,
-  legend: ChartLegendItem[],
-  chartHeight: number,
-  chartWidth: number,
-) {
-  if (legend.length === 0) return;
-
-  const ns = 'http://www.w3.org/2000/svg';
-  const paddingX = 20;
-  const rowHeight = 22;
-  const markerWidth = 18;
-  const labelFactor = 7;
-  let cursorX = paddingX;
-  let cursorY = chartHeight + 22;
-
-  legend.forEach((item) => {
-    const itemWidth = markerWidth + 10 + item.label.length * labelFactor;
-    if (cursorX + itemWidth > chartWidth - paddingX) {
-      cursorX = paddingX;
-      cursorY += rowHeight;
-    }
-
-    if (item.variant === 'bar') {
-      const rect = document.createElementNS(ns, 'rect');
-      rect.setAttribute('x', String(cursorX));
-      rect.setAttribute('y', String(cursorY - 9));
-      rect.setAttribute('width', '14');
-      rect.setAttribute('height', '14');
-      rect.setAttribute('rx', '3');
-      rect.setAttribute('fill', item.color);
-      root.appendChild(rect);
-    } else {
-      const line = document.createElementNS(ns, 'line');
-      line.setAttribute('x1', String(cursorX));
-      line.setAttribute('y1', String(cursorY - 2));
-      line.setAttribute('x2', String(cursorX + markerWidth));
-      line.setAttribute('y2', String(cursorY - 2));
-      line.setAttribute('stroke', item.color);
-      line.setAttribute('stroke-width', item.variant === 'area' ? '8' : '4');
-      line.setAttribute('stroke-linecap', 'round');
-      if (item.variant === 'area') {
-        line.setAttribute('stroke-opacity', '0.55');
-      }
-      if (item.dashed) {
-        line.setAttribute('stroke-dasharray', '6 5');
-      }
-      root.appendChild(line);
-    }
-
-    const label = document.createElementNS(ns, 'text');
-    label.setAttribute('x', String(cursorX + markerWidth + 8));
-    label.setAttribute('y', String(cursorY + 2));
-    label.setAttribute('fill', 'currentColor');
-    label.setAttribute('font-size', '12');
-    label.setAttribute('font-family', 'system-ui, sans-serif');
-    label.textContent = item.label;
-    root.appendChild(label);
-
-    cursorX += itemWidth + 16;
-  });
-}
-
-function buildExportMarkup(svg: SVGSVGElement, legend: ChartLegendItem[], background: string) {
-  const serializer = new XMLSerializer();
-  const clonedSvg = svg.cloneNode(true) as SVGSVGElement;
-  const parent = svg.parentElement as HTMLElement | null;
-  const { width, height } = getChartDimensions(svg, parent?.clientWidth || 1200, parent?.clientHeight || 480);
-  const legendRows = legend.length > 0 ? Math.ceil(legend.length / 4) : 0;
-  const legendHeight = legendRows > 0 ? 26 + legendRows * 22 : 0;
-  const totalHeight = height + legendHeight;
-  const ns = 'http://www.w3.org/2000/svg';
-
-  const exportSvg = document.createElementNS(ns, 'svg');
-  exportSvg.setAttribute('xmlns', ns);
-  exportSvg.setAttribute('width', String(width));
-  exportSvg.setAttribute('height', String(totalHeight));
-  exportSvg.setAttribute('viewBox', `0 0 ${width} ${totalHeight}`);
-  exportSvg.setAttribute('fill', 'none');
-  exportSvg.setAttribute('color', getComputedStyle(document.documentElement).getPropertyValue('--text-strong').trim() || COLORS.fallback.exportText);
-
-  const backgroundRect = document.createElementNS(ns, 'rect');
-  backgroundRect.setAttribute('x', '0');
-  backgroundRect.setAttribute('y', '0');
-  backgroundRect.setAttribute('width', String(width));
-  backgroundRect.setAttribute('height', String(totalHeight));
-  backgroundRect.setAttribute('fill', background);
-  exportSvg.appendChild(backgroundRect);
-
-  clonedSvg.setAttribute('x', '0');
-  clonedSvg.setAttribute('y', '0');
-  clonedSvg.setAttribute('width', String(width));
-  clonedSvg.setAttribute('height', String(height));
-  exportSvg.appendChild(clonedSvg);
-
-  appendLegend(exportSvg, legend, height, width);
-
-  return serializer.serializeToString(exportSvg);
-}
-
-function downloadSvg(filename: string, markup: string) {
-  const blob = new Blob([markup], { type: 'image/svg+xml;charset=utf-8' });
-  const objectUrl = URL.createObjectURL(blob);
-  const link = document.createElement('a');
-  link.href = objectUrl;
-  link.download = filename;
-  document.body.appendChild(link);
-  link.click();
-  link.remove();
-  URL.revokeObjectURL(objectUrl);
-}
-
-function sanitizeFilename(value: string) {
-  return value.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '');
-}
 
 export function ChartPanel({
   title,
@@ -194,9 +63,13 @@ export function ChartPanel({
     const chartSvg = chartRef.current?.querySelector('svg');
     if (!(chartSvg instanceof SVGSVGElement)) return;
 
+    const textColor = getComputedStyle(document.documentElement).getPropertyValue('--text-strong').trim() || COLORS.fallback.exportText;
     const background = getComputedStyle(document.documentElement).getPropertyValue('--bg').trim() || COLORS.fallback.exportBackground;
-    const markup = buildExportMarkup(chartSvg, legend, background);
-    downloadSvg(`${sanitizeFilename(exportName)}.svg`, markup);
+    void exportChartAsSvg(chartSvg, `${sanitizeFilename(exportName)}.svg`, {
+      legend,
+      textColor,
+      backgroundColor: background,
+    });
   };
 
   const actions = (

--- a/src/components/dashboard/EnergyTab.tsx
+++ b/src/components/dashboard/EnergyTab.tsx
@@ -1,19 +1,16 @@
 import { useMemo } from 'react';
 import { Gauge, Zap } from 'lucide-react';
 import { Area, AreaChart, CartesianGrid, Line, LineChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
-import type { OpenF1Driver } from '../../api/openf1';
+import { useDriverContext } from '../../contexts/useDriverContext';
 import type { ComparisonPoint, DriverLapSummary, SpeedPoint } from './types';
 import { ChartSkeleton, ChartTip, NoData } from './shared';
 import { ChartPanel, type ChartLegendItem } from './ChartPanel';
 
 type Props = {
   lapNum: number;
-  driverNums: number[];
-  driverMap: Record<number, OpenF1Driver>;
   speedData: SpeedPoint[];
   comparisonEnergyData: ComparisonPoint[];
   lapSummaries: DriverLapSummary[];
-  driverColor: (driverNumber: number) => string;
   telemetryLoading: boolean;
   embedMode?: boolean;
   onEmbedPanel?: (panelId: string) => void;
@@ -21,16 +18,14 @@ type Props = {
 
 export function EnergyTab({
   lapNum,
-  driverNums,
-  driverMap,
   speedData,
   comparisonEnergyData,
   lapSummaries,
-  driverColor,
   telemetryLoading,
   embedMode = false,
   onEmbedPanel,
 }: Props) {
+  const { driverNums, driverMap, driverColor } = useDriverContext();
   const chartGrid = 'var(--chart-grid)';
   const chartAxis = 'var(--chart-axis)';
   const chartRpm = 'var(--chart-rpm)';

--- a/src/components/dashboard/IntervalsTab.tsx
+++ b/src/components/dashboard/IntervalsTab.tsx
@@ -1,27 +1,26 @@
 import { useMemo } from 'react';
 import { Gauge } from 'lucide-react';
 import { CartesianGrid, Line, LineChart, ReferenceLine, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
-import type { OpenF1Driver, OpenF1Interval } from '../../api/openf1';
+import type { OpenF1Interval } from '../../api/openf1';
 import { withAlpha } from '../../constants/colors';
+import { useDriverContext } from '../../contexts/useDriverContext';
 import { CardGridSkeleton, ChartSkeleton, ChartTip, NoData, Panel, Stat } from './shared';
 import { ChartPanel } from './ChartPanel';
 import type { ChartLegendItem } from './ChartPanel';
 
 type Props = {
-  driverNums: number[];
-  driverMap: Record<number, OpenF1Driver>;
   intervals: OpenF1Interval[] | null;
   intervalsLoading: boolean;
-  driverColor: (driverNumber: number) => string;
   embedMode?: boolean;
   onEmbedPanel?: (panelId: string) => void;
 };
 
-const DRS_THRESHOLD = 1.0;
+const DRS_DETECTION_WINDOW_S = 1.0;
 const MAX_CHART_POINTS = 120;
 const MAX_GAP_DISPLAY = 60; // cap gaps at 60s to avoid outliers from safety cars crushing the chart
 
-export function IntervalsTab({ driverNums, driverMap, intervals, intervalsLoading, driverColor, embedMode = false, onEmbedPanel }: Props) {
+export function IntervalsTab({ intervals, intervalsLoading, embedMode = false, onEmbedPanel }: Props) {
+  const { driverNums, driverMap, driverColor } = useDriverContext();
   const chartGrid = 'var(--chart-grid)';
   const chartAxis = 'var(--chart-axis)';
 
@@ -76,7 +75,7 @@ export function IntervalsTab({ driverNums, driverMap, intervals, intervalsLoadin
     const windows = activeDrvs.map((n) => {
       const samples = byDriver[n] ?? [];
       const drsCount = samples.filter(
-        (s) => s.interval != null && s.interval <= DRS_THRESHOLD && s.interval >= 0,
+        (s) => s.interval != null && s.interval <= DRS_DETECTION_WINDOW_S && s.interval >= 0,
       ).length;
       const pct = samples.length > 0 ? Math.round((drsCount / samples.length) * 100) : 0;
       return { driverNum: n, drsCount, pct };
@@ -150,9 +149,9 @@ export function IntervalsTab({ driverNums, driverMap, intervals, intervalsLoadin
                 {interval != null && interval >= 0 && (
                   <div
                     className="mt-1 text-[10px] font-mono"
-                    style={{ color: interval <= DRS_THRESHOLD ? 'var(--accent)' : 'var(--text-dim)' }}
+                    style={{ color: interval <= DRS_DETECTION_WINDOW_S ? 'var(--accent)' : 'var(--text-dim)' }}
                   >
-                    {interval <= DRS_THRESHOLD ? '● DRS ' : ''}+{interval.toFixed(3)}s ahead
+                    {interval <= DRS_DETECTION_WINDOW_S ? '● DRS ' : ''}+{interval.toFixed(3)}s ahead
                   </div>
                 )}
               </div>
@@ -166,7 +165,7 @@ export function IntervalsTab({ driverNums, driverMap, intervals, intervalsLoadin
         <Panel
           title="DRS Window Time"
           icon={<Gauge size={14} style={{ color: 'var(--accent)' }} />}
-          sub={`Proportion of session where each driver was within ${DRS_THRESHOLD}s of the car ahead`}
+          sub={`Proportion of session where each driver was within ${DRS_DETECTION_WINDOW_S}s of the car ahead`}
         >
           <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
             {drsWindows.map(({ driverNum, drsCount, pct }) => (
@@ -201,7 +200,7 @@ export function IntervalsTab({ driverNums, driverMap, intervals, intervalsLoadin
                 <XAxis dataKey="t" tick={{ fill: chartAxis, fontSize: 10 }} stroke={chartGrid} label={{ value: 'Session progress →', position: 'insideBottomRight', offset: -4, fill: chartAxis, fontSize: 10 }} />
                 <YAxis tick={{ fill: chartAxis, fontSize: 10 }} stroke={chartGrid} tickFormatter={(v: number) => `+${v.toFixed(0)}s`} />
                 <Tooltip content={<ChartTip />} />
-                <ReferenceLine y={DRS_THRESHOLD} stroke="var(--accent)" strokeDasharray="5 4" label={{ value: 'DRS 1s', fill: 'var(--accent)', fontSize: 9, position: 'right' }} />
+                <ReferenceLine y={DRS_DETECTION_WINDOW_S} stroke="var(--accent)" strokeDasharray="5 4" label={{ value: 'DRS 1s', fill: 'var(--accent)', fontSize: 9, position: 'right' }} />
                 {driverNums.map((n) => (
                   <Line
                     key={n}
@@ -240,7 +239,7 @@ export function IntervalsTab({ driverNums, driverMap, intervals, intervalsLoadin
                 <XAxis dataKey="t" tick={{ fill: chartAxis, fontSize: 10 }} stroke={chartGrid} />
                 <YAxis tick={{ fill: chartAxis, fontSize: 10 }} stroke={chartGrid} domain={[0, 5]} tickFormatter={(v: number) => `${v.toFixed(1)}s`} />
                 <Tooltip content={<ChartTip />} />
-                <ReferenceLine y={DRS_THRESHOLD} stroke="var(--accent)" strokeDasharray="5 4" label={{ value: 'DRS', fill: 'var(--accent)', fontSize: 9, position: 'right' }} />
+                <ReferenceLine y={DRS_DETECTION_WINDOW_S} stroke="var(--accent)" strokeDasharray="5 4" label={{ value: 'DRS', fill: 'var(--accent)', fontSize: 9, position: 'right' }} />
                 {driverNums.map((n) => (
                   <Line
                     key={n}

--- a/src/components/dashboard/PositionsTab.tsx
+++ b/src/components/dashboard/PositionsTab.tsx
@@ -1,19 +1,17 @@
 import { useMemo } from 'react';
 import { TrendingDown } from 'lucide-react';
 import { CartesianGrid, Line, LineChart, ReferenceLine, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
-import type { OpenF1Driver, OpenF1Position } from '../../api/openf1';
+import type { OpenF1Position } from '../../api/openf1';
 import { teamColor, withAlpha } from '../../constants/colors';
+import { useDriverContext } from '../../contexts/useDriverContext';
 import { CardGridSkeleton, ChartSkeleton, ChartTip, NoData, Panel } from './shared';
 import { ChartPanel } from './ChartPanel';
 import type { ChartLegendItem } from './ChartPanel';
 
 type Props = {
-  driverNums: number[];
-  driverMap: Record<number, OpenF1Driver>;
   positions: OpenF1Position[] | null;
   positionsLoading: boolean;
   lapNum: number;
-  driverColor: (driverNumber: number) => string;
   embedMode?: boolean;
   onEmbedPanel?: (panelId: string) => void;
 };
@@ -24,7 +22,8 @@ type PositionSample = {
   timestamp: number;
 };
 
-export function PositionsTab({ driverNums, driverMap, positions, positionsLoading, lapNum, driverColor, embedMode = false, onEmbedPanel }: Props) {
+export function PositionsTab({ positions, positionsLoading, lapNum, embedMode = false, onEmbedPanel }: Props) {
+  const { driverNums, driverMap, driverColor } = useDriverContext();
   const chartGrid = 'var(--chart-grid)';
   const chartAxis = 'var(--chart-axis)';
 

--- a/src/components/dashboard/RadioTab.tsx
+++ b/src/components/dashboard/RadioTab.tsx
@@ -1,17 +1,18 @@
 import { useMemo } from 'react';
 import { Headphones } from 'lucide-react';
-import type { OpenF1Driver, OpenF1TeamRadio } from '../../api/openf1';
+import type { OpenF1TeamRadio } from '../../api/openf1';
+import { useDriverContext } from '../../contexts/useDriverContext';
 import { Err, NoData, Panel, Spinner } from './shared';
 
 type Props = {
   loading: boolean;
   error: string | null;
   messages: OpenF1TeamRadio[];
-  driverMap: Record<number, OpenF1Driver>;
   onRetry?: () => void;
 };
 
-export function RadioTab({ loading, error, messages, driverMap, onRetry }: Props) {
+export function RadioTab({ loading, error, messages, onRetry }: Props) {
+  const { driverMap } = useDriverContext();
   const radioMessages = useMemo(
     () => messages.map((message, index) => {
       const driver = driverMap[message.driver_number];

--- a/src/components/dashboard/StrategyTab.tsx
+++ b/src/components/dashboard/StrategyTab.tsx
@@ -1,7 +1,8 @@
 import { useMemo } from 'react';
 import { CircleDot, Timer } from 'lucide-react';
-import type { OpenF1Driver, OpenF1Pit, OpenF1Stint } from '../../api/openf1';
+import type { OpenF1Pit, OpenF1Stint } from '../../api/openf1';
 import { COLORS, teamColor, withAlpha } from '../../constants/colors';
+import { useDriverContext } from '../../contexts/useDriverContext';
 import { CardGridSkeleton, EmbedPanelButton, NoData, Panel, TableSkeleton } from './shared';
 
 const COMPOUND_COLORS: Record<string, string> = {
@@ -10,8 +11,6 @@ const COMPOUND_COLORS: Record<string, string> = {
 
 type Props = {
   lapNum: number;
-  driverNums: number[];
-  driverMap: Record<number, OpenF1Driver>;
   stintsLoading: boolean;
   stintsByDriver: Record<number, OpenF1Stint[]>;
   pitsLoading: boolean;
@@ -55,7 +54,8 @@ type PitStopCard = {
   lapNumber: number;
 };
 
-export function StrategyTab({ lapNum, driverNums, driverMap, stintsLoading, stintsByDriver, pitsLoading, filteredPits, embedMode = false, onEmbedPanel }: Props) {
+export function StrategyTab({ lapNum, stintsLoading, stintsByDriver, pitsLoading, filteredPits, embedMode = false, onEmbedPanel }: Props) {
+  const { driverNums, driverMap } = useDriverContext();
   const fallbackDriverNums = useMemo(() => Object.keys(stintsByDriver).map(Number), [stintsByDriver]);
   const strategyDriverNums = useMemo(
     () => (driverNums.length > 0 ? driverNums : fallbackDriverNums.slice(0, 6)),

--- a/src/components/dashboard/TelemetryTab.tsx
+++ b/src/components/dashboard/TelemetryTab.tsx
@@ -1,8 +1,8 @@
 import { useMemo } from 'react';
 import { Activity, Gauge, Timer, Trophy, Waves } from 'lucide-react';
 import { Area, CartesianGrid, ComposedChart, Line, LineChart, ReferenceLine, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
-import type { OpenF1Driver } from '../../api/openf1';
 import { COLORS } from '../../constants/colors';
+import { useDriverContext } from '../../contexts/useDriverContext';
 import type { ComparisonPoint, DriverLapSummary, SectorRow, SpeedPoint } from './types';
 import { ChartSkeleton, ChartTip, EmbedPanelButton, Err, NoData, Panel, TableSkeleton } from './shared';
 import { ChartPanel, type ChartLegendItem } from './ChartPanel';
@@ -21,9 +21,6 @@ type Props = {
   lapTimeData: Array<Record<string, number | string>>;
   lapDeltaData: Array<Record<string, number | string>>;
   lapSummaries: DriverLapSummary[];
-  driverNums: number[];
-  driverMap: Record<number, OpenF1Driver>;
-  driverColor: (driverNumber: number) => string;
   embedMode?: boolean;
   onEmbedPanel?: (panelId: string) => void;
   onTelemetryRetry?: () => void;
@@ -49,13 +46,11 @@ export function TelemetryTab({
   lapTimeData,
   lapDeltaData,
   lapSummaries,
-  driverNums,
-  driverMap,
-  driverColor,
   embedMode = false,
   onEmbedPanel,
   onTelemetryRetry,
 }: Props) {
+  const { driverNums, driverMap, driverColor } = useDriverContext();
   const leader = lapSummaries[0];
   const bestS1 = getBestSector(sectorRows, 's1');
   const bestS2 = getBestSector(sectorRows, 's2');

--- a/src/components/dashboard/TrackMapTab.tsx
+++ b/src/components/dashboard/TrackMapTab.tsx
@@ -1,19 +1,18 @@
 import { useMemo } from 'react';
 import { Map } from 'lucide-react';
-import type { OpenF1Driver, OpenF1Location } from '../../api/openf1';
+import type { OpenF1Location } from '../../api/openf1';
+import { useDriverContext } from '../../contexts/useDriverContext';
 import { ChartSkeleton, EmbedPanelButton, NoData, Panel } from './shared';
 
 type Props = {
   lapNum: number;
-  driverNums: number[];
-  driverMap: Record<number, OpenF1Driver>;
   locationByDriver: Record<number, OpenF1Location[] | null>;
   locationLoading: boolean;
-  driverColor: (driverNumber: number) => string;
   embedMode?: boolean;
   onEmbedPanel?: (panelId: string) => void;
 };
 
+/** SVG canvas dimensions for the track map. Chosen to preserve OpenF1 GPS coordinate aspect ratio. */
 const MAP_W = 600;
 const MAP_H = 380;
 const PADDING = 36;
@@ -29,6 +28,11 @@ function subsample<T>(arr: T[], max: number): T[] {
   return arr.filter((_, i) => i % step === 0);
 }
 
+/**
+ * Builds a GPS-to-SVG projection for the selected lap paths: it bounds all raw
+ * OpenF1 x/y samples, scales them into the padded SVG viewport, centers the
+ * fitted track, and flips the Y axis so the circuit renders in screen space.
+ */
 function buildTransform(rawPoints: { x: number; y: number }[]) {
   if (rawPoints.length === 0) return null;
   const xs = rawPoints.map((p) => p.x);
@@ -52,7 +56,8 @@ function toPolyline(pts: { nx: number; ny: number }[]) {
   return pts.map((p) => `${p.nx.toFixed(1)},${p.ny.toFixed(1)}`).join(' ');
 }
 
-export function TrackMapTab({ lapNum, driverNums, driverMap, locationByDriver, locationLoading, driverColor, embedMode = false, onEmbedPanel }: Props) {
+export function TrackMapTab({ lapNum, locationByDriver, locationLoading, embedMode = false, onEmbedPanel }: Props) {
+  const { driverNums, driverMap, driverColor } = useDriverContext();
   const { trackPolyline, driverPaths, driverMarkers, startPt, activeDrivers } = useMemo((): {
     trackPolyline: string;
     driverPaths: Partial<Record<number, string>>;

--- a/src/contexts/DriverContext.tsx
+++ b/src/contexts/DriverContext.tsx
@@ -1,0 +1,15 @@
+import { useMemo, type ReactNode } from 'react';
+import { DriverContext, type DriverContextValue } from './driverContextValue';
+
+type DriverProviderProps = DriverContextValue & {
+  children: ReactNode;
+};
+
+export function DriverProvider({ children, driverNums, driverMap, driverColor }: DriverProviderProps) {
+  const value = useMemo(
+    () => ({ driverNums, driverMap, driverColor }),
+    [driverColor, driverMap, driverNums],
+  );
+
+  return <DriverContext.Provider value={value}>{children}</DriverContext.Provider>;
+}

--- a/src/contexts/driverContextValue.ts
+++ b/src/contexts/driverContextValue.ts
@@ -1,0 +1,10 @@
+import { createContext } from 'react';
+import type { OpenF1Driver } from '../api/openf1';
+
+export type DriverContextValue = {
+  driverNums: number[];
+  driverMap: Record<number, OpenF1Driver>;
+  driverColor: (driverNumber: number) => string;
+};
+
+export const DriverContext = createContext<DriverContextValue | null>(null);

--- a/src/contexts/useDriverContext.ts
+++ b/src/contexts/useDriverContext.ts
@@ -1,0 +1,10 @@
+import { useContext } from 'react';
+import { DriverContext } from './driverContextValue';
+
+export function useDriverContext() {
+  const context = useContext(DriverContext);
+  if (!context) {
+    throw new Error('useDriverContext must be used within DriverProvider');
+  }
+  return context;
+}

--- a/src/hooks/useDashboardSelectionData.ts
+++ b/src/hooks/useDashboardSelectionData.ts
@@ -140,7 +140,6 @@ export function useDashboardSelectionData({
       ?? (lapOptions.includes(2) ? 2 : lapOptions[0] ?? null);
   }, [lapOptions, preferredWinnerLaps]);
 
-  const primaryDriverNumber = driverNums[0];
   const telemetryWindows = useMemo(() => {
     return driverNums.map((driverNumber) => {
       const laps = allLaps[driverNumber] || [];
@@ -153,14 +152,6 @@ export function useDashboardSelectionData({
       };
     });
   }, [allLaps, driverNums, lapNum]);
-  const primaryLap = useMemo(
-    () => (allLaps[primaryDriverNumber] || []).find((lap) => lap.lap_number === lapNum) || null,
-    [allLaps, lapNum, primaryDriverNumber],
-  );
-  const nextPrimaryLap = useMemo(
-    () => (allLaps[primaryDriverNumber] || []).find((lap) => lap.lap_number === lapNum + 1) || null,
-    [allLaps, lapNum, primaryDriverNumber],
-  );
 
   useEffect(() => {
     if (circuitOptions.length > 0 && !circuit) {
@@ -210,8 +201,5 @@ export function useDashboardSelectionData({
     allLaps,
     lapOptions,
     telemetryWindows,
-    primaryDriverNumber,
-    primaryLapStart: primaryLap?.date_start || null,
-    nextPrimaryLapStart: nextPrimaryLap?.date_start || null,
   };
 }

--- a/src/hooks/useDashboardViewModel.ts
+++ b/src/hooks/useDashboardViewModel.ts
@@ -34,8 +34,14 @@ type Params = {
   telemetryByDriver: Record<number, OpenF1CarData[] | null>;
 };
 
+// 120 samples gives sub-1% lap-progress resolution while keeping Recharts payloads small.
 const NORMALIZED_TELEMETRY_POINTS = 120;
 
+/**
+ * Samples each selected driver's telemetry at evenly spaced lap-progress percentages.
+ * OpenF1 car-data arrays can have different sample counts per driver/lap, so each
+ * progress bucket maps to the nearest index in that driver's own telemetry series.
+ */
 function buildNormalizedComparisonData(
   driverNums: number[],
   telemetryByDriver: Record<number, OpenF1CarData[] | null>,

--- a/src/hooks/useOpenF1.ts
+++ b/src/hooks/useOpenF1.ts
@@ -53,6 +53,26 @@ function setCacheEntry<T>(key: string, data: T) {
   }
 }
 
+function createInflightEntry<T>(
+  key: string,
+  fetcher: (signal: AbortSignal) => Promise<T>,
+): InflightEntry<T> {
+  const controller = new AbortController();
+  return {
+    controller,
+    consumers: 0,
+    promise: (async () => {
+      try {
+        const data = await fetcher(controller.signal);
+        setCacheEntry(key, data);
+        return data;
+      } finally {
+        inflight.delete(key);
+      }
+    })(),
+  };
+}
+
 function clearExpiredCacheEntries() {
   const now = Date.now();
   for (const [key, entry] of cache.entries()) {
@@ -160,37 +180,24 @@ function useFetch<T>(key: string | null, fetcher: (signal: AbortSignal) => Promi
 
     let entry = inflight.get(key) as InflightEntry<T> | undefined;
     if (!entry) {
-      const controller = new AbortController();
-      entry = {
-        controller,
-        consumers: 0,
-        promise: fetcherRef.current(controller.signal)
-          .then((data) => {
-            setCacheEntry(key, data);
-            inflight.delete(key);
-            return data;
-          })
-          .catch((err: unknown) => {
-            inflight.delete(key);
-            throw err;
-          }),
-      };
+      entry = createInflightEntry(key, fetcherRef.current);
       inflight.set(key, entry as InflightEntry<unknown>);
     }
     entry.consumers += 1;
 
-    entry.promise
-      .then(data => {
+    void (async () => {
+      try {
+        const data = await entry.promise;
         if (seqRef.current !== seq) return; // stale
         setState({ data, loading: false, error: null });
-      })
-      .catch((err: unknown) => {
+      } catch (err: unknown) {
         if (seqRef.current !== seq) return;
         if (isAbortError(err)) return;
         console.warn(`[OpenF1] ${key}:`, err);
         const message = err instanceof Error ? err.message : 'Unknown error';
         setState({ data: cached?.data ?? null, loading: false, error: message });
-      });
+      }
+    })();
 
     return () => {
       const active = inflight.get(key) as InflightEntry<T> | undefined;

--- a/src/utils/exportChart.ts
+++ b/src/utils/exportChart.ts
@@ -1,0 +1,158 @@
+export type ExportChartLegendItem = {
+  label: string;
+  color: string;
+  variant?: 'line' | 'area' | 'bar';
+  dashed?: boolean;
+};
+
+type ExportChartOptions = {
+  legend?: ExportChartLegendItem[];
+  textColor: string;
+  backgroundColor: string;
+};
+
+const SVG_NS = 'http://www.w3.org/2000/svg';
+const DEFAULT_EXPORT_WIDTH = 1200;
+const DEFAULT_EXPORT_HEIGHT = 480;
+const LEGEND_PADDING_X_PX = 20;
+const LEGEND_ROW_HEIGHT_PX = 22;
+const LEGEND_MARKER_WIDTH_PX = 18;
+const LEGEND_MARKER_GAP_PX = 10;
+const LEGEND_ITEM_GAP_PX = 16;
+const LEGEND_TOP_PADDING_PX = 26;
+const LEGEND_ITEMS_PER_ROW_ESTIMATE = 4;
+const APPROX_CHAR_WIDTH_PX = 7;
+
+function getChartDimensions(svg: SVGSVGElement, fallbackWidth: number, fallbackHeight: number) {
+  const widthAttr = Number(svg.getAttribute('width'));
+  const heightAttr = Number(svg.getAttribute('height'));
+  const viewBox = svg.viewBox.baseVal;
+
+  return {
+    width: Number.isFinite(widthAttr) && widthAttr > 0 ? widthAttr : (viewBox?.width || fallbackWidth || DEFAULT_EXPORT_WIDTH),
+    height: Number.isFinite(heightAttr) && heightAttr > 0 ? heightAttr : (viewBox?.height || fallbackHeight || DEFAULT_EXPORT_HEIGHT),
+  };
+}
+
+function appendLegend(
+  root: SVGSVGElement,
+  legend: ExportChartLegendItem[],
+  chartHeight: number,
+  chartWidth: number,
+) {
+  if (legend.length === 0) return;
+
+  let cursorX = LEGEND_PADDING_X_PX;
+  let cursorY = chartHeight + LEGEND_ROW_HEIGHT_PX;
+
+  legend.forEach((item) => {
+    const itemWidth = LEGEND_MARKER_WIDTH_PX + LEGEND_MARKER_GAP_PX + item.label.length * APPROX_CHAR_WIDTH_PX;
+    if (cursorX + itemWidth > chartWidth - LEGEND_PADDING_X_PX) {
+      cursorX = LEGEND_PADDING_X_PX;
+      cursorY += LEGEND_ROW_HEIGHT_PX;
+    }
+
+    if (item.variant === 'bar') {
+      const rect = document.createElementNS(SVG_NS, 'rect');
+      rect.setAttribute('x', String(cursorX));
+      rect.setAttribute('y', String(cursorY - 9));
+      rect.setAttribute('width', '14');
+      rect.setAttribute('height', '14');
+      rect.setAttribute('rx', '3');
+      rect.setAttribute('fill', item.color);
+      root.appendChild(rect);
+    } else {
+      const line = document.createElementNS(SVG_NS, 'line');
+      line.setAttribute('x1', String(cursorX));
+      line.setAttribute('y1', String(cursorY - 2));
+      line.setAttribute('x2', String(cursorX + LEGEND_MARKER_WIDTH_PX));
+      line.setAttribute('y2', String(cursorY - 2));
+      line.setAttribute('stroke', item.color);
+      line.setAttribute('stroke-width', item.variant === 'area' ? '8' : '4');
+      line.setAttribute('stroke-linecap', 'round');
+      if (item.variant === 'area') {
+        line.setAttribute('stroke-opacity', '0.55');
+      }
+      if (item.dashed) {
+        line.setAttribute('stroke-dasharray', '6 5');
+      }
+      root.appendChild(line);
+    }
+
+    const label = document.createElementNS(SVG_NS, 'text');
+    label.setAttribute('x', String(cursorX + LEGEND_MARKER_WIDTH_PX + 8));
+    label.setAttribute('y', String(cursorY + 2));
+    label.setAttribute('fill', 'currentColor');
+    label.setAttribute('font-size', '12');
+    label.setAttribute('font-family', 'system-ui, sans-serif');
+    label.textContent = item.label;
+    root.appendChild(label);
+
+    cursorX += itemWidth + LEGEND_ITEM_GAP_PX;
+  });
+}
+
+function buildExportMarkup(svg: SVGSVGElement, options: Required<ExportChartOptions>) {
+  const serializer = new XMLSerializer();
+  const clonedSvg = svg.cloneNode(true) as SVGSVGElement;
+  const parent = svg.parentElement as HTMLElement | null;
+  const { width, height } = getChartDimensions(svg, parent?.clientWidth || DEFAULT_EXPORT_WIDTH, parent?.clientHeight || DEFAULT_EXPORT_HEIGHT);
+  const legendRows = options.legend.length > 0 ? Math.ceil(options.legend.length / LEGEND_ITEMS_PER_ROW_ESTIMATE) : 0;
+  const legendHeight = legendRows > 0 ? LEGEND_TOP_PADDING_PX + legendRows * LEGEND_ROW_HEIGHT_PX : 0;
+  const totalHeight = height + legendHeight;
+
+  const exportSvg = document.createElementNS(SVG_NS, 'svg');
+  exportSvg.setAttribute('xmlns', SVG_NS);
+  exportSvg.setAttribute('width', String(width));
+  exportSvg.setAttribute('height', String(totalHeight));
+  exportSvg.setAttribute('viewBox', `0 0 ${width} ${totalHeight}`);
+  exportSvg.setAttribute('fill', 'none');
+  exportSvg.setAttribute('color', options.textColor);
+
+  const backgroundRect = document.createElementNS(SVG_NS, 'rect');
+  backgroundRect.setAttribute('x', '0');
+  backgroundRect.setAttribute('y', '0');
+  backgroundRect.setAttribute('width', String(width));
+  backgroundRect.setAttribute('height', String(totalHeight));
+  backgroundRect.setAttribute('fill', options.backgroundColor);
+  exportSvg.appendChild(backgroundRect);
+
+  clonedSvg.setAttribute('x', '0');
+  clonedSvg.setAttribute('y', '0');
+  clonedSvg.setAttribute('width', String(width));
+  clonedSvg.setAttribute('height', String(height));
+  exportSvg.appendChild(clonedSvg);
+
+  appendLegend(exportSvg, options.legend, height, width);
+
+  return serializer.serializeToString(exportSvg);
+}
+
+function downloadSvg(filename: string, markup: string) {
+  const blob = new Blob([markup], { type: 'image/svg+xml;charset=utf-8' });
+  const objectUrl = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = objectUrl;
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
+  URL.revokeObjectURL(objectUrl);
+}
+
+export function sanitizeFilename(value: string) {
+  return value.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '');
+}
+
+export async function exportChartAsSvg(
+  svg: SVGSVGElement,
+  filename: string,
+  options: ExportChartOptions,
+) {
+  const markup = buildExportMarkup(svg, {
+    legend: options.legend ?? [],
+    textColor: options.textColor,
+    backgroundColor: options.backgroundColor,
+  });
+  downloadSvg(filename, markup);
+}


### PR DESCRIPTION
## Summary
- Extract chart SVG export logic into a utility and name remaining magic constants
- Remove unused selection outputs and simplify repeated driver data hook patterns
- Add driver context provider and JSDoc for OpenF1 URLs, telemetry normalization, dashboard URLs, and track map transforms
- Standardize OpenF1 hook async error handling and rename the DRS detection window constant

## Verification
- npm run typecheck
- npm run lint
- npm run build